### PR TITLE
Feat: optimize chat store flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "memorall",
   "description": "Memorall - AI-powered memory and knowledge management browser.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "type": "module",
   "homepage": "https://zrg-team.github.io/memorall",

--- a/public/runner/modes/webllm-runner.js
+++ b/public/runner/modes/webllm-runner.js
@@ -9,6 +9,7 @@ let prebuiltAppConfig;
 const loadedModelsCache = new Map(); // Cache model metadata
 const activeOperations = new Map(); // Track active operations for abort support
 const IMAGE_EMBED_SIZE = 1921;
+const MODEL_LOAD_STALL_TIMEOUT_MS = 2 * 60 * 1000;
 
 // Query downloaded status via WebLLM engine APIs when available
 async function isDownloaded(modelId) {
@@ -300,15 +301,45 @@ async function loadWebLLMModel(modelId, notifyProgress) {
 		throw new Error(`Model ${modelId} not found in WebLLM prebuilt config`);
 	}
 
-	currentProgressCallback = notifyProgress;
+	let stallTimer = null;
+	let rejectStalledLoad = null;
+
+	const clearStallTimer = () => {
+		if (stallTimer !== null) {
+			clearTimeout(stallTimer);
+			stallTimer = null;
+		}
+	};
+
+	const resetStallTimer = (engine) => {
+		clearStallTimer();
+		stallTimer = setTimeout(() => {
+			const message =
+				`WebLLM did not report model load progress for ${Math.round(
+					MODEL_LOAD_STALL_TIMEOUT_MS / 1000,
+				)} seconds. The browser may have blocked the download or WebGPU initialization.`;
+			try {
+				engine?.reloadController?.abort?.();
+			} catch {}
+			rejectStalledLoad?.(new Error(message));
+		}, MODEL_LOAD_STALL_TIMEOUT_MS);
+	};
+
+	currentProgressCallback = (info) => {
+		if (notifyProgress) {
+			notifyProgress(info);
+		}
+	};
 
 	const engine = new WebLLMEngine({
+		appConfig: prebuiltAppConfig,
 		initProgressCallback: (progressData) => {
 			const { progress, text } = progressData || {};
 			if (currentProgressCallback) {
 				const percent = Math.max(0, Math.min(100, Math.round(progress * 100)));
 				currentProgressCallback({ loaded: progress, total: 1, percent, text });
 			}
+			resetStallTimer(engine);
 		},
 	});
 
@@ -316,8 +347,31 @@ async function loadWebLLMModel(modelId, notifyProgress) {
 		throw new Error("MLCEngine.reload is not available");
 	}
 
-	await engine.reload(modelId);
-	currentProgressCallback = null;
+	try {
+		currentProgressCallback({
+			loaded: 0,
+			total: 1,
+			percent: 1,
+			text: `Starting WebLLM load for ${modelId}`,
+		});
+		resetStallTimer(engine);
+
+		await Promise.race([
+			engine.reload(modelId),
+			new Promise((_, reject) => {
+				rejectStalledLoad = reject;
+			}),
+		]);
+	} catch (error) {
+		try {
+			await engine.unload?.();
+		} catch {}
+		throw error;
+	} finally {
+		clearStallTimer();
+		currentProgressCallback = null;
+		rejectStalledLoad = null;
+	}
 
 	return engine;
 }

--- a/src/embedded/chat-service.ts
+++ b/src/embedded/chat-service.ts
@@ -3,22 +3,13 @@ import type { ChatMessage } from "./types";
 import type {
 	ChatResult,
 	ChatPayload,
-	ConversationContext,
 } from "@/services/background-jobs/handlers/process-chat";
 import type { UnifiedFlowConfig } from "@/services/flows/interfaces/flow-config";
 import type {
 	ChatCompletionChunkToolCall,
 	ChatCompletionMessageToolCall,
 } from "@/types/openai";
-import {
-	appendTextPart,
-	cloneContentParts,
-	completeRunningExecutionParts,
-	stripTransientExecutionParts,
-	upsertExecutionPart,
-	upsertToolParts,
-} from "@/services/chat/content-parts";
-import type { ComplexContent } from "@/types/chat";
+import type { ComplexContent, ConversationContext } from "@/types/chat";
 
 export interface ChatServiceOptions {
 	messages: ChatMessage[];
@@ -198,7 +189,6 @@ export class EmbeddedChatService {
 			systemMessages,
 			conversation,
 			onProgress,
-			onContentParts,
 			onAction,
 			onToolCalls,
 			onExecuteStart,
@@ -266,10 +256,6 @@ export class EmbeddedChatService {
 			const toolCallAccumulator: ToolCallAccumulator = new Map();
 			let finalToolCalls: ChatCompletionMessageToolCall[] = [];
 			let finalUsage: EmbeddedChatStreamResult["usage"];
-			let contentParts: ComplexContent = [];
-			const emitContentParts = () => {
-				onContentParts?.(cloneContentParts(contentParts));
-			};
 
 			if (!("stream" in result)) {
 				throw new Error("WRONG OUPUT");
@@ -296,11 +282,7 @@ export class EmbeddedChatService {
 								finalActions,
 								chatResult.metadata.actions,
 							);
-							contentParts = upsertToolParts(contentParts, finalActions);
 							onAction?.([...finalActions]);
-						}
-						if (chatResult.metadata?.contentParts) {
-							contentParts = chatResult.metadata.contentParts as ComplexContent;
 						}
 						if (chatResult.metadata?.tool_calls) {
 							finalToolCalls = chatResult.metadata.tool_calls;
@@ -310,7 +292,6 @@ export class EmbeddedChatService {
 							finalUsage = chatResult.metadata.usage;
 						}
 						onProgress?.(finalContent, true);
-						emitContentParts();
 					}
 					continue;
 				}
@@ -335,41 +316,29 @@ export class EmbeddedChatService {
 						onToolCalls?.(finalToolCalls);
 					}
 
-					const content = delta?.content;
+					const isToolResultChunk =
+						delta?.role === "tool" || !!delta?.tool_call_id;
+					const content = isToolResultChunk ? "" : delta?.content;
 					if (content) {
 						finalContent += content;
-						contentParts = appendTextPart(
-							completeRunningExecutionParts(contentParts),
-							content,
-						);
 						onProgress?.(finalContent, false);
-						emitContentParts();
 					}
 				} else if (chatResult.type === "execute-start") {
 					const event = {
 						node: chatResult.node,
 						metadata: chatResult.metadata,
 					};
-					contentParts = upsertExecutionPart(contentParts, event);
 					onExecuteStart?.(event);
-					emitContentParts();
 				} else if (chatResult.type === "action" && chatResult.actions) {
 					finalActions = mergeActions(finalActions, chatResult.actions);
-					contentParts = upsertToolParts(contentParts, chatResult.actions);
 					onAction?.([...finalActions]);
-					emitContentParts();
 				} else if (chatResult.type === "final") {
 					finalContent = chatResult.content || finalContent;
-					contentParts = completeRunningExecutionParts(contentParts);
 					if (chatResult.metadata?.actions) {
 						finalActions = mergeActions(
 							finalActions,
 							chatResult.metadata.actions,
 						);
-						contentParts = upsertToolParts(contentParts, finalActions);
-					}
-					if (chatResult.metadata?.contentParts) {
-						contentParts = chatResult.metadata.contentParts as ComplexContent;
 					}
 					if (chatResult.metadata?.tool_calls) {
 						finalToolCalls = chatResult.metadata.tool_calls;
@@ -380,17 +349,12 @@ export class EmbeddedChatService {
 					}
 					onProgress?.(finalContent, false);
 					onAction?.([...finalActions]);
-					emitContentParts();
 				}
 			}
 
 			// Final progress update
 			if (finalContent) {
 				onProgress?.(finalContent, true);
-			}
-
-			if (finalContent && !contentParts.some((part) => part.type === "text")) {
-				contentParts = appendTextPart(contentParts, finalContent);
 			}
 
 			// Store actions for later retrieval
@@ -401,7 +365,7 @@ export class EmbeddedChatService {
 
 			return {
 				content: finalContent,
-				contentParts: stripTransientExecutionParts(contentParts),
+				contentParts: [],
 				actions: finalActions,
 				toolCalls:
 					finalToolCalls.length > 0

--- a/src/embedded/chat-service.ts
+++ b/src/embedded/chat-service.ts
@@ -3,6 +3,7 @@ import type { ChatMessage } from "./types";
 import type {
 	ChatResult,
 	ChatPayload,
+	ConversationContext,
 } from "@/services/background-jobs/handlers/process-chat";
 import type { UnifiedFlowConfig } from "@/services/flows/interfaces/flow-config";
 import type {
@@ -27,6 +28,7 @@ export interface ChatServiceOptions {
 	agentFlowId?: string;
 	flowConfig?: UnifiedFlowConfig;
 	systemMessages?: string[];
+	conversation?: ConversationContext;
 }
 
 export interface ChatAction {
@@ -194,6 +196,7 @@ export class EmbeddedChatService {
 			agentFlowId,
 			flowConfig,
 			systemMessages,
+			conversation,
 			onProgress,
 			onContentParts,
 			onAction,
@@ -246,6 +249,7 @@ export class EmbeddedChatService {
 				topicId,
 				agentFlowId,
 				flowConfig,
+				conversation,
 				streamConfig: {
 					minWordsToStream: 5,
 					streamToolCallsImmediately: true,

--- a/src/embedded/hooks/use-embedded-chat-session.ts
+++ b/src/embedded/hooks/use-embedded-chat-session.ts
@@ -205,7 +205,6 @@ export const useEmbeddedChatSession = ({
 			let currentContent = "";
 			let latestActions: ChatAction[] = [];
 			let latestToolCalls: unknown[] = [];
-			const startTime = Date.now();
 
 			try {
 				const topicId =
@@ -281,6 +280,10 @@ export const useEmbeddedChatSession = ({
 					flowConfig: coAgentEnabled
 						? createCoAgentEnabledFlowConfig()
 						: undefined,
+					conversation: {
+						id: storedAssistantMessage.conversationId ?? "embedded",
+						inProgressMessage: { id: assistantMessageId },
+					},
 					signal: controller.signal,
 					onProgress: (content: string, isComplete: boolean) => {
 						currentContent = content;
@@ -369,41 +372,26 @@ export const useEmbeddedChatSession = ({
 				currentContent = result.content || currentContent;
 				latestActions = cloneActions(result.actions || latestActions);
 				latestToolCalls = result.toolCalls || latestToolCalls;
-				const endTime = Date.now();
-				const timeToAnswer = (endTime - startTime) / 1000;
-				const totalTokens =
-					result.usage?.total_tokens ?? Math.round(currentContent.length / 4);
-				const outputTokens =
-					result.usage?.completion_tokens ??
-					Math.round(currentContent.length / 4);
-
-				await embeddedChatHistoryService.finalizeMessage(assistantMessageId, {
-					content: currentContent,
-					metadata: {
-						actions: latestActions,
-						tool_calls: latestToolCalls,
-						model: selectedModel,
-						timeToAnswer,
-						tokensPerSecond: timeToAnswer > 0 ? outputTokens / timeToAnswer : 0,
-						estimatedTokens: totalTokens,
-						usage: result.usage,
-					},
-				});
+				setMessages((prev) =>
+					prev.map((message) =>
+						message.id === assistantMessageId
+							? {
+									...message,
+									content: currentContent,
+									isStreaming: false,
+									metadata: {
+										...message.metadata,
+										actions: latestActions,
+										tool_calls: latestToolCalls,
+										model: selectedModel,
+									},
+								}
+							: message,
+					),
+				);
 			} catch (error) {
 				logError("Chat submission error:", error);
 				const errorContent = currentContent || t("errorMessage");
-				try {
-					await embeddedChatHistoryService.finalizeMessage(assistantMessageId, {
-						content: errorContent,
-						metadata: {
-							actions: latestActions,
-							tool_calls: latestToolCalls,
-							model: selectedModel,
-						},
-					});
-				} catch (saveError) {
-					logError("Failed to persist embedded error message:", saveError);
-				}
 				setMessages((prev) =>
 					prev.map((message) => {
 						if (message.id === assistantMessageId) {
@@ -411,6 +399,12 @@ export const useEmbeddedChatSession = ({
 								...message,
 								content: errorContent,
 								isStreaming: false,
+								metadata: {
+									...message.metadata,
+									actions: latestActions,
+									tool_calls: latestToolCalls,
+									model: selectedModel,
+								},
 							};
 						}
 						return message;

--- a/src/main/components/RightApplicationLayout.tsx
+++ b/src/main/components/RightApplicationLayout.tsx
@@ -96,7 +96,13 @@ const RightPanelVerticalRail: React.FC<RightPanelVerticalRailProps> = ({
 					})}
 				</TooltipProvider>
 			</div>
-			<div className="mt-auto flex flex-col items-center pb-1">
+			<div className="mt-auto flex flex-col items-center gap-1 pb-1">
+				<ProcessMonitor
+					tooltipSide="left"
+					popoverSide="left"
+					popoverAlign="end"
+					triggerClassName="h-9 w-9 text-muted-foreground hover:text-foreground"
+				/>
 				<SettingPanel
 					setIsReloadingModel={setIsReloadingModel}
 					setReloadProgress={setReloadProgress}

--- a/src/main/components/RightApplicationLayout.tsx
+++ b/src/main/components/RightApplicationLayout.tsx
@@ -36,6 +36,76 @@ interface RightApplicationLayoutProps {
 	onCollapsedChange?: (collapsed: boolean) => void;
 }
 
+type SettingsPanelStateProps = Pick<
+	React.ComponentProps<typeof SettingPanel>,
+	"setIsReloadingModel" | "setReloadProgress"
+>;
+
+type RightPanelVerticalRailProps = SettingsPanelStateProps & {
+	runtimeCount: number;
+	onOpenPanel: () => void;
+	renderRuntimeBadge: (count: number) => React.ReactNode;
+};
+
+const RightPanelVerticalRail: React.FC<RightPanelVerticalRailProps> = ({
+	runtimeCount,
+	onOpenPanel,
+	renderRuntimeBadge,
+	setIsReloadingModel,
+	setReloadProgress,
+}) => {
+	const { t } = useTranslation();
+
+	return (
+		<aside className="flex h-full min-h-0 w-14 flex-col items-center border-l bg-app py-2">
+			<Button
+				type="button"
+				variant="ghost"
+				size="icon"
+				className="h-9 w-9 text-muted-foreground hover:text-foreground"
+				aria-label="Expand workspace panel"
+				title="Expand workspace panel"
+				onClick={onOpenPanel}
+			>
+				<ChevronsLeft size={17} />
+			</Button>
+			<div className="mt-3 flex flex-col items-center gap-1">
+				<TooltipProvider>
+					{workspaceNavigationItems.map((item) => {
+						const IconComponent = item.icon;
+						return (
+							<Tooltip key={item.path}>
+								<TooltipTrigger asChild>
+									<Link
+										to={item.path}
+										onClick={onOpenPanel}
+										className="relative flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
+									>
+										<IconComponent size={16} />
+										{item.path === "/runtime"
+											? renderRuntimeBadge(runtimeCount)
+											: null}
+									</Link>
+								</TooltipTrigger>
+								<TooltipContent side="left">
+									<p>{t(item.nameKey)}</p>
+								</TooltipContent>
+							</Tooltip>
+						);
+					})}
+				</TooltipProvider>
+			</div>
+			<div className="mt-auto flex flex-col items-center pb-1">
+				<SettingPanel
+					setIsReloadingModel={setIsReloadingModel}
+					setReloadProgress={setReloadProgress}
+					tooltipSide="left"
+				/>
+			</div>
+		</aside>
+	);
+};
+
 export const RightApplicationLayout: React.FC<RightApplicationLayoutProps> = ({
 	children,
 	collapsed = false,
@@ -79,6 +149,11 @@ export const RightApplicationLayout: React.FC<RightApplicationLayoutProps> = ({
 		onCollapsedChange?.(false);
 	};
 
+	const settingsPanelStateProps = {
+		setIsReloadingModel,
+		setReloadProgress,
+	} satisfies SettingsPanelStateProps;
+
 	const renderRuntimeBadge = (count: number) =>
 		count > 0 ? (
 			<span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-500 px-1 text-[10px] font-semibold leading-none text-white shadow-sm">
@@ -86,47 +161,46 @@ export const RightApplicationLayout: React.FC<RightApplicationLayoutProps> = ({
 			</span>
 		) : null;
 
+	const reloadOverlay = isReloadingModel ? (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+			<div className="mx-4 w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
+				<h3 className="mb-4 text-lg font-semibold">
+					{t("embedding.reloading", {
+						defaultValue: "Reloading Embedding Model",
+					})}
+				</h3>
+				<p className="mb-4 text-sm text-muted-foreground">
+					{reloadProgress.stage || "Downloading model..."}
+				</p>
+				<div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+					<div
+						className="h-full bg-primary transition-all duration-300"
+						style={{ width: `${reloadProgress.progress}%` }}
+					/>
+				</div>
+				<p className="mt-2 text-center text-xs text-muted-foreground">
+					{+reloadProgress.progress.toFixed(2)}%
+				</p>
+				<p className="mt-4 text-xs text-muted-foreground">
+					{t("embedding.pleaseWait", {
+						defaultValue: "Please wait, do not close this window...",
+					})}
+				</p>
+			</div>
+		</div>
+	) : null;
+
 	if (collapsed) {
 		return (
-			<aside className="flex h-full min-h-0 w-14 flex-col items-center border-l bg-app py-2">
-				<Button
-					type="button"
-					variant="ghost"
-					size="icon"
-					className="h-9 w-9 text-muted-foreground hover:text-foreground"
-					aria-label="Expand workspace panel"
-					title="Expand workspace panel"
-					onClick={() => openPanel()}
-				>
-					<ChevronsLeft size={17} />
-				</Button>
-				<div className="mt-3 flex flex-col items-center gap-1">
-					<TooltipProvider>
-						{workspaceNavigationItems.map((item) => {
-							const IconComponent = item.icon;
-							return (
-								<Tooltip key={item.path}>
-									<TooltipTrigger asChild>
-										<Link
-											to={item.path}
-											onClick={() => openPanel()}
-											className="relative flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-white/5 hover:text-foreground"
-										>
-											<IconComponent size={16} />
-											{item.path === "/runtime"
-												? renderRuntimeBadge(runtimeCount)
-												: null}
-										</Link>
-									</TooltipTrigger>
-									<TooltipContent side="left">
-										<p>{t(item.nameKey)}</p>
-									</TooltipContent>
-								</Tooltip>
-							);
-						})}
-					</TooltipProvider>
-				</div>
-			</aside>
+			<>
+				<RightPanelVerticalRail
+					runtimeCount={runtimeCount}
+					onOpenPanel={openPanel}
+					renderRuntimeBadge={renderRuntimeBadge}
+					{...settingsPanelStateProps}
+				/>
+				{reloadOverlay}
+			</>
 		);
 	}
 
@@ -268,10 +342,7 @@ export const RightApplicationLayout: React.FC<RightApplicationLayoutProps> = ({
 								</TooltipProvider>
 							)}
 							<ProcessMonitor />
-							<SettingPanel
-								setIsReloadingModel={setIsReloadingModel}
-								setReloadProgress={setReloadProgress}
-							/>
+							<SettingPanel {...settingsPanelStateProps} />
 						</div>
 					</div>
 				</div>
@@ -281,34 +352,7 @@ export const RightApplicationLayout: React.FC<RightApplicationLayoutProps> = ({
 				{children}
 			</div>
 
-			{isReloadingModel && (
-				<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-					<div className="mx-4 w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
-						<h3 className="mb-4 text-lg font-semibold">
-							{t("embedding.reloading", {
-								defaultValue: "Reloading Embedding Model",
-							})}
-						</h3>
-						<p className="mb-4 text-sm text-muted-foreground">
-							{reloadProgress.stage || "Downloading model..."}
-						</p>
-						<div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-							<div
-								className="h-full bg-primary transition-all duration-300"
-								style={{ width: `${reloadProgress.progress}%` }}
-							/>
-						</div>
-						<p className="mt-2 text-center text-xs text-muted-foreground">
-							{+reloadProgress.progress.toFixed(2)}%
-						</p>
-						<p className="mt-4 text-xs text-muted-foreground">
-							{t("embedding.pleaseWait", {
-								defaultValue: "Please wait, do not close this window...",
-							})}
-						</p>
-					</div>
-				</div>
-			)}
+			{reloadOverlay}
 		</div>
 	);
 };

--- a/src/main/components/RightApplicationLayout.tsx
+++ b/src/main/components/RightApplicationLayout.tsx
@@ -55,6 +55,7 @@ const RightPanelVerticalRail: React.FC<RightPanelVerticalRailProps> = ({
 	setReloadProgress,
 }) => {
 	const { t } = useTranslation();
+	const expandPanelLabel = t("rightPanel.expandWorkspacePanel");
 
 	return (
 		<aside className="flex h-full min-h-0 w-14 flex-col items-center border-l bg-app py-2">
@@ -63,8 +64,8 @@ const RightPanelVerticalRail: React.FC<RightPanelVerticalRailProps> = ({
 				variant="ghost"
 				size="icon"
 				className="h-9 w-9 text-muted-foreground hover:text-foreground"
-				aria-label="Expand workspace panel"
-				title="Expand workspace panel"
+				aria-label={expandPanelLabel}
+				title={expandPanelLabel}
 				onClick={onOpenPanel}
 			>
 				<ChevronsLeft size={17} />
@@ -144,6 +145,7 @@ export const RightApplicationLayout: React.FC<RightApplicationLayoutProps> = ({
 	const isDebugSelected = debugNavigationItems.some(
 		(item) => item.path === location.pathname,
 	);
+	const collapsePanelLabel = t("rightPanel.collapseWorkspacePanel");
 
 	const openPanel = () => {
 		onCollapsedChange?.(false);
@@ -165,12 +167,10 @@ export const RightApplicationLayout: React.FC<RightApplicationLayoutProps> = ({
 		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
 			<div className="mx-4 w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
 				<h3 className="mb-4 text-lg font-semibold">
-					{t("embedding.reloading", {
-						defaultValue: "Reloading Embedding Model",
-					})}
+					{t("reloading", { ns: "embedding" })}
 				</h3>
 				<p className="mb-4 text-sm text-muted-foreground">
-					{reloadProgress.stage || "Downloading model..."}
+					{reloadProgress.stage || t("downloadingModel", { ns: "embedding" })}
 				</p>
 				<div className="h-2 w-full overflow-hidden rounded-full bg-muted">
 					<div
@@ -182,9 +182,7 @@ export const RightApplicationLayout: React.FC<RightApplicationLayoutProps> = ({
 					{+reloadProgress.progress.toFixed(2)}%
 				</p>
 				<p className="mt-4 text-xs text-muted-foreground">
-					{t("embedding.pleaseWait", {
-						defaultValue: "Please wait, do not close this window...",
-					})}
+					{t("pleaseWait", { ns: "embedding" })}
 				</p>
 			</div>
 		</div>
@@ -226,15 +224,15 @@ export const RightApplicationLayout: React.FC<RightApplicationLayoutProps> = ({
 											variant="ghost"
 											size="icon"
 											className="h-9 w-9 text-muted-foreground hover:text-foreground"
-											aria-label="Collapse workspace panel"
-											title="Collapse workspace panel"
+											aria-label={collapsePanelLabel}
+											title={collapsePanelLabel}
 											onClick={() => onCollapsedChange?.(true)}
 										>
 											<ChevronsRight size={16} />
 										</Button>
 									</TooltipTrigger>
 									<TooltipContent side="bottom">
-										<p>Collapse workspace panel</p>
+										<p>{collapsePanelLabel}</p>
 									</TooltipContent>
 								</Tooltip>
 								{workspaceNavigationItems.map((item) => {

--- a/src/main/components/molecules/ProcessMonitor.tsx
+++ b/src/main/components/molecules/ProcessMonitor.tsx
@@ -19,6 +19,12 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/main/components/ui/popover";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/main/components/ui/tooltip";
 import { Button } from "@/main/components/ui/button";
 import { Separator } from "@/main/components/ui/separator";
 import { Badge } from "@/main/components/ui/badge";
@@ -138,7 +144,17 @@ const ProcessItem: React.FC<ProcessItemProps> = ({
 
 // formatRelativeTime will be created inside component to access translations
 
-export const ProcessMonitor: React.FC = () => {
+export const ProcessMonitor: React.FC<{
+	tooltipSide?: "top" | "right" | "bottom" | "left";
+	popoverAlign?: "start" | "center" | "end";
+	popoverSide?: "top" | "right" | "bottom" | "left";
+	triggerClassName?: string;
+}> = ({
+	tooltipSide = "bottom",
+	popoverAlign = "end",
+	popoverSide,
+	triggerClassName,
+}) => {
 	const { t } = useTranslation("common");
 
 	// Create formatRelativeTime with translations
@@ -312,22 +328,38 @@ export const ProcessMonitor: React.FC = () => {
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger asChild>
-				<Button
-					variant="ghost"
-					size="icon"
-					className="relative h-8 w-8"
-					title={t("processMonitor.viewProcesses")}
-				>
-					<Bell className="h-4 w-4" />
-					{hasActiveProcesses && (
-						<span className="absolute top-0 right-0 flex h-2 w-2">
-							<span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
-							<span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
-						</span>
-					)}
-				</Button>
+				<span>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									variant="ghost"
+									size="icon"
+									className={cn("relative h-8 w-8", triggerClassName)}
+									aria-label={t("processMonitor.viewProcesses")}
+									title={t("processMonitor.viewProcesses")}
+								>
+									<Bell className="h-4 w-4" />
+									{hasActiveProcesses && (
+										<span className="absolute right-0 top-0 flex h-2 w-2">
+											<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
+											<span className="relative inline-flex h-2 w-2 rounded-full bg-blue-500" />
+										</span>
+									)}
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side={tooltipSide}>
+								<p>{t("processMonitor.title")}</p>
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				</span>
 			</PopoverTrigger>
-			<PopoverContent className="w-[400px] p-0" align="end">
+			<PopoverContent
+				className="w-[400px] p-0"
+				align={popoverAlign}
+				side={popoverSide}
+			>
 				<div className="flex items-center justify-between px-4 py-3 border-b">
 					<div className="flex items-center gap-2">
 						<Activity className="h-4 w-4" />

--- a/src/main/components/molecules/SettingPanel.tsx
+++ b/src/main/components/molecules/SettingPanel.tsx
@@ -61,7 +61,8 @@ export const SettingPanel: React.FC<{
 			progress: number;
 		}>
 	>;
-}> = ({ setIsReloadingModel, setReloadProgress }) => {
+	tooltipSide?: "top" | "right" | "bottom" | "left";
+}> = ({ setIsReloadingModel, setReloadProgress, tooltipSide = "bottom" }) => {
 	const navigate = useNavigate();
 	const { theme, setTheme } = useTheme();
 	const embeddingSize = useCurrentEmbeddingSize();
@@ -192,7 +193,7 @@ export const SettingPanel: React.FC<{
 							</button>
 						</DropdownMenuTrigger>
 					</TooltipTrigger>
-					<TooltipContent side="bottom">
+					<TooltipContent side={tooltipSide}>
 						<p>{t("common.settings")}</p>
 					</TooltipContent>
 				</Tooltip>

--- a/src/main/i18n/locales/en/chat.json
+++ b/src/main/i18n/locales/en/chat.json
@@ -132,6 +132,11 @@
 			"answer": "Generating answer"
 		}
 	},
+	"toolStatus": {
+		"running": "Running",
+		"error": "Error",
+		"done": "Done"
+	},
 	"workflow": {
 		"showDetails": "Show run details",
 		"hideDetails": "Hide run details",

--- a/src/main/i18n/locales/en/common.json
+++ b/src/main/i18n/locales/en/common.json
@@ -70,6 +70,10 @@
 		"total": "Total",
 		"version": "Version {{version}}"
 	},
+	"rightPanel": {
+		"expandWorkspacePanel": "Expand workspace panel",
+		"collapseWorkspacePanel": "Collapse workspace panel"
+	},
 	"appLoading": {
 		"title": "Initializing Memorall...",
 		"subtitle": "Setting up your AI-powered knowledge assistant",

--- a/src/main/i18n/locales/en/embedding.json
+++ b/src/main/i18n/locales/en/embedding.json
@@ -46,6 +46,9 @@
 		"enterQuery": "Enter a query to find semantically similar items"
 	},
 	"label": "Embedding Size",
+	"reloading": "Reloading Embedding Model",
+	"downloadingModel": "Downloading model...",
+	"pleaseWait": "Please wait, do not close this window...",
 	"changeWarning": "Changing embedding size will require clearing existing embeddings in nodes and edges. Do you want to continue?",
 	"clearError": "Failed to clear embeddings. Please try again.",
 	"sizes": {

--- a/src/main/i18n/locales/vn/chat.json
+++ b/src/main/i18n/locales/vn/chat.json
@@ -132,6 +132,11 @@
 			"answer": "Tạo câu trả lời"
 		}
 	},
+	"toolStatus": {
+		"running": "Đang chạy",
+		"error": "Lỗi",
+		"done": "Hoàn tất"
+	},
 	"workflow": {
 		"showDetails": "Hiện chi tiết lượt chạy",
 		"hideDetails": "Ẩn chi tiết lượt chạy",

--- a/src/main/i18n/locales/vn/common.json
+++ b/src/main/i18n/locales/vn/common.json
@@ -69,6 +69,10 @@
 		"noResults": "Không tìm thấy kết quả",
 		"total": "Tổng"
 	},
+	"rightPanel": {
+		"expandWorkspacePanel": "Mở rộng bảng workspace",
+		"collapseWorkspacePanel": "Thu gọn bảng workspace"
+	},
 	"appLoading": {
 		"title": "Đang khởi tạo Memorall...",
 		"subtitle": "Thiết lập trợ lý tri thức AI của bạn",

--- a/src/main/i18n/locales/vn/embedding.json
+++ b/src/main/i18n/locales/vn/embedding.json
@@ -20,6 +20,9 @@
 		"similarity": "Độ tương tự"
 	},
 	"label": "Kích thước nhúng",
+	"reloading": "Đang tải lại mô hình nhúng",
+	"downloadingModel": "Đang tải mô hình...",
+	"pleaseWait": "Vui lòng chờ, không đóng cửa sổ này...",
 	"changeWarning": "Thay đổi kích thước nhúng sẽ xóa các nhúng hiện có trong nodes và edges. Bạn có muốn tiếp tục?",
 	"clearError": "Không thể xóa nhúng. Vui lòng thử lại.",
 	"sizes": {

--- a/src/main/modules/chat/components/MessageActions.tsx
+++ b/src/main/modules/chat/components/MessageActions.tsx
@@ -326,19 +326,19 @@ const TaskItemRenderer: React.FC<TaskItemRendererProps> = React.memo(
 		);
 
 		return (
-			<div className="group/action relative grid grid-cols-[1rem_minmax(0,1fr)] gap-2.5">
+			<div className="group/action relative grid grid-cols-[1rem_minmax(0,1fr)] gap-2.5 animate-in fade-in-0 slide-in-from-top-1 duration-200 ease-out">
 				<div className="relative flex justify-center pt-3">
 					{index < total - 1 ? (
-						<div className="absolute left-1/2 top-5 h-[calc(100%+0.5rem)] w-px -translate-x-1/2 bg-border/70" />
+						<div className="absolute left-1/2 top-5 h-[calc(100%+0.5rem)] w-px -translate-x-1/2 bg-border/70 transition-colors duration-200 group-hover/action:bg-border" />
 					) : (
-						<div className="absolute left-1/2 top-5 h-10 w-px -translate-x-1/2 bg-gradient-to-b from-border/70 to-border/25" />
+						<div className="absolute left-1/2 top-5 h-10 w-px -translate-x-1/2 bg-gradient-to-b from-border/70 to-border/25 transition-opacity duration-200 group-hover/action:opacity-80" />
 					)}
 					<span
 						className={cn(
-							"relative z-10 h-2 w-2 rounded-full border bg-background transition-colors",
+							"relative z-10 h-2 w-2 rounded-full border bg-background transition-[background-color,border-color,box-shadow,transform] duration-200 ease-out",
 							isOpen
-								? "border-primary bg-primary"
-								: "border-muted-foreground/35 group-hover/action:border-primary/60",
+								? "scale-110 border-primary bg-primary shadow-[0_0_0_3px_hsl(var(--primary)/0.12)]"
+								: "border-muted-foreground/35 group-hover/action:scale-105 group-hover/action:border-primary/60",
 						)}
 						aria-hidden="true"
 					/>
@@ -353,13 +353,13 @@ const TaskItemRenderer: React.FC<TaskItemRendererProps> = React.memo(
 						<button
 							type="button"
 							className={cn(
-								"flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors duration-150",
-								isOpen ? "bg-muted/40" : "hover:bg-muted/25",
+								"flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-[background-color,box-shadow,transform] duration-200 ease-out hover:bg-muted/25 active:scale-[0.995]",
+								isOpen && "bg-muted/40 shadow-sm",
 							)}
 						>
 							<span
 								className={cn(
-									"flex h-7 w-7 shrink-0 items-center justify-center rounded-md border transition-colors",
+									"flex h-7 w-7 shrink-0 items-center justify-center rounded-md border transition-[background-color,border-color,color,transform] duration-200 ease-out group-hover/action:scale-105",
 									isOpen
 										? "border-primary/25 bg-primary/10 text-primary"
 										: "border-border/55 bg-background/70 text-muted-foreground",
@@ -367,19 +367,19 @@ const TaskItemRenderer: React.FC<TaskItemRendererProps> = React.memo(
 							>
 								<Icon className="h-4 w-4" />
 							</span>
-							<span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+							<span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground transition-colors duration-200">
 								{title}
 							</span>
 							<ChevronDown
 								className={cn(
-									"h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+									"h-4 w-4 shrink-0 text-muted-foreground transition-[transform,color] duration-200 ease-out",
 									isOpen && "rotate-180 text-foreground",
 								)}
 							/>
 						</button>
 					</TaskTrigger>
-					<TaskContent className="[&>div]:mt-2 [&>div]:border-l-0 [&>div]:pl-0">
-						<div className="rounded-lg border border-border/60 bg-background/80 p-3 shadow-sm">
+					<TaskContent className="overflow-hidden duration-200 ease-out [&>div]:mt-2 [&>div]:border-l-0 [&>div]:pl-0">
+						<div className="rounded-lg border border-border/60 bg-background/80 p-3 shadow-sm animate-in fade-in-0 zoom-in-95 duration-200 ease-out">
 							<TaskItem className="text-sm">
 								<ActionRenderErrorBoundary item={item}>
 									<ActionContent item={item} isOpen={isOpen} />

--- a/src/main/modules/chat/components/MessageActions.tsx
+++ b/src/main/modules/chat/components/MessageActions.tsx
@@ -89,6 +89,9 @@ const EXACT_ICON_MAPPINGS: Record<string, LucideIcon> = {
 	pdf_to_image: FileImage,
 };
 
+const looksLikeI18nKey = (value: string): boolean =>
+	value.includes(".") && /^[\w.-]+$/.test(value);
+
 export const getActionIcon = (name: string): LucideIcon => {
 	const exact = EXACT_ICON_MAPPINGS[name];
 	if (exact) {
@@ -114,12 +117,39 @@ export const translateActionName = (
 		return translated;
 	}
 
+	if (looksLikeI18nKey(actionName)) {
+		const commonTranslated = t(actionName, {
+			ns: "common",
+			defaultValue: "",
+		});
+		if (commonTranslated) {
+			return commonTranslated;
+		}
+	}
+
 	const coAgentTitle = getCoAgentActionTitle(actionName);
 	if (coAgentTitle) {
 		return coAgentTitle;
 	}
 
 	return actionName.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase());
+};
+
+const translateActionDescription = (
+	t: ReturnType<typeof useTranslation>["t"],
+	description: string,
+): string => {
+	const trimmed = description.trim();
+	if (!looksLikeI18nKey(trimmed)) {
+		return description;
+	}
+
+	const commonTranslated = t(trimmed, {
+		ns: "common",
+		defaultValue: "",
+	});
+
+	return commonTranslated || description;
 };
 
 type ActionRenderer = (
@@ -252,13 +282,18 @@ class ActionRenderErrorBoundary extends React.Component<
 
 const ActionContent: React.FC<ActionContentProps> = React.memo(
 	({ item, isOpen }) => {
+		const { t } = useTranslation("chat");
 		const renderer = ACTION_RENDERERS[item.name] || defaultActionRenderer;
+		const displayItem = {
+			...item,
+			description: translateActionDescription(t, item.description),
+		};
 		try {
-			return <>{renderer(item, isOpen)}</>;
+			return <>{renderer(displayItem, isOpen)}</>;
 		} catch (error) {
 			return (
 				<ActionRenderFallback
-					item={item}
+					item={displayItem}
 					error={error instanceof Error ? error : new Error(String(error))}
 				/>
 			);

--- a/src/main/modules/chat/components/MessageActions.tsx
+++ b/src/main/modules/chat/components/MessageActions.tsx
@@ -89,8 +89,9 @@ const EXACT_ICON_MAPPINGS: Record<string, LucideIcon> = {
 	pdf_to_image: FileImage,
 };
 
+const I18N_KEY_REGEX = /^[\w.-]+$/;
 const looksLikeI18nKey = (value: string): boolean =>
-	value.includes(".") && /^[\w.-]+$/.test(value);
+	value.includes(".") && I18N_KEY_REGEX.test(value);
 
 export const getActionIcon = (name: string): LucideIcon => {
 	const exact = EXACT_ICON_MAPPINGS[name];
@@ -222,9 +223,7 @@ const ActionRenderFallback: React.FC<{
 			<div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-900 dark:text-amber-100">
 				<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
 				<div className="min-w-0">
-					<div className="font-medium">Renderer fallback</div>
 					<div className="text-xs break-words text-amber-800/90 dark:text-amber-100/90">
-						Failed to render this tool output. Showing raw content instead.
 						{error?.message ? ` ${error.message}` : ""}
 					</div>
 				</div>

--- a/src/main/modules/chat/components/MessageGroup.tsx
+++ b/src/main/modules/chat/components/MessageGroup.tsx
@@ -12,6 +12,7 @@ const hasRenderableMessageContent = (
 ) => {
 	if (message.content) return true;
 	if (message.complexContent) return true;
+	if (message.parts) return true;
 	if (!message.metadata || typeof message.metadata !== "object") return false;
 	return (
 		("actions" in message.metadata &&
@@ -123,6 +124,7 @@ export const MessageGroup: React.FC<MessageGroupProps> = React.memo(
 				metadata: {
 					actions: inProgressMessage.actions,
 					executeState: inProgressMessage.executeState,
+					executions: inProgressMessage.executions,
 				},
 				createdAt: new Date(),
 				updatedAt: new Date(),
@@ -133,6 +135,7 @@ export const MessageGroup: React.FC<MessageGroupProps> = React.memo(
 				type: "",
 				role: "assistant" as const,
 				complexContent: inProgressMessage.complexContent,
+				parts: inProgressMessage.parts,
 				topicId: null,
 				embedding: null,
 				embeddingSmall: null,

--- a/src/main/modules/chat/components/MessageRenderer.tsx
+++ b/src/main/modules/chat/components/MessageRenderer.tsx
@@ -77,11 +77,14 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 		const assistantContentParts = useMemo<AssistantContentPart[]>(() => {
 			if (message.role !== "assistant" || !complexContent) return [];
 			const parts = complexContent.filter(isAssistantContentPart);
-			const hasAssistantOnlyPart = parts.some(
-				(part) => part.type === "tool" || part.type === "execution",
-			);
-			return hasAssistantOnlyPart ? parts : [];
+			return parts.some((part) =>
+				part.type === "text" ? part.text.trim() : true,
+			)
+				? parts
+				: [];
 		}, [complexContent, message.role]);
+		const hasRenderableContent =
+			message.content.trim().length > 0 || assistantContentParts.length > 0;
 		const showGenericStreamingStatus =
 			isStreaming && assistantContentParts.length === 0;
 
@@ -186,7 +189,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 						{complexContent && (
 							<MessageComplexImages complexContent={complexContent} />
 						)}
-						{!message.content &&
+						{!hasRenderableContent &&
 						assistantContentParts.length === 0 &&
 						isLastMessage &&
 						isStreaming ? (

--- a/src/main/modules/chat/components/MessageRenderer.tsx
+++ b/src/main/modules/chat/components/MessageRenderer.tsx
@@ -10,7 +10,12 @@ import {
 } from "@/main/components/ui/shadcn-io/ai/message";
 import type { Message as DBMessage } from "@/services/database/types";
 import type { MessageActionItem } from "@/main/modules/chat/components/types";
-import type { AttachedDocumentRef, ComplexContent } from "@/types/chat";
+import type {
+	AssistantExecutionPart,
+	AttachedDocumentRef,
+	ComplexContent,
+	MessageParts,
+} from "@/types/chat";
 import { cn } from "@/lib/utils";
 import { MessageActions } from "./MessageActions";
 import { MessageFooter, type MessageFooterMetadata } from "./MessageFooter";
@@ -24,6 +29,10 @@ import {
 	type AssistantContentPart,
 } from "./message/AssistantContentFlow";
 import { MessageErrorNotice } from "./message/MessageErrorNotice";
+import {
+	buildAssistantContentParts,
+	hasAssistantContentParts,
+} from "./message/message-parts-adapter";
 
 interface MessageMetadata extends MessageFooterMetadata {
 	actions?: MessageActionItem[];
@@ -40,6 +49,7 @@ interface MessageMetadata extends MessageFooterMetadata {
 		node: string;
 		metadata?: Record<string, unknown>;
 	};
+	executions?: AssistantExecutionPart[];
 }
 
 interface MessageRendererProps {
@@ -76,18 +86,19 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 
 		const assistantContentParts = useMemo<AssistantContentPart[]>(() => {
 			if (message.role !== "assistant" || !complexContent) return [];
-			const parts = complexContent.filter(isAssistantContentPart);
+			const parts = (complexContent as unknown[]).filter(isAssistantContentPart);
 			return parts.some((part) =>
 				part.type === "text" ? part.text.trim() : true,
 			)
 				? parts
 				: [];
 		}, [complexContent, message.role]);
-		const hasRenderableContent =
-			message.content.trim().length > 0 || assistantContentParts.length > 0;
-		const showGenericStreamingStatus =
-			isStreaming && assistantContentParts.length === 0;
-
+		const messageParts = useMemo<MessageParts | null>(() => {
+			if (message.role !== "assistant") return null;
+			if (!message.parts || !Array.isArray(message.parts)) return null;
+			return message.parts as MessageParts;
+		}, [message.parts, message.role]);
+		const metadata = message.metadata as MessageMetadata | undefined;
 		const actions = useMemo<MessageActionItem[]>(() => {
 			if (!message.metadata || typeof message.metadata !== "object") return [];
 			if (!("actions" in message.metadata)) return [];
@@ -102,20 +113,39 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 			return message.metadata.attachedDocuments as AttachedDocumentRef[];
 		}, [message.metadata]);
 
-		const executeState = useMemo(() => {
-			const metadata = message.metadata as MessageMetadata | undefined;
-			return metadata?.executeState;
-		}, [message.metadata]);
+		const executeState = useMemo(() => metadata?.executeState, [metadata]);
+		const executionParts = useMemo<AssistantExecutionPart[]>(
+			() => (Array.isArray(metadata?.executions) ? metadata.executions : []),
+			[metadata],
+		);
+		const partsContentParts = useMemo<AssistantContentPart[]>(
+			() =>
+				message.role === "assistant"
+					? buildAssistantContentParts({
+							parts: messageParts,
+							executions: executionParts,
+							executeState: isStreaming ? executeState : undefined,
+						})
+					: [],
+			[executeState, executionParts, isStreaming, message.role, messageParts],
+		);
+		const renderedAssistantContentParts =
+			partsContentParts.length > 0 ? partsContentParts : assistantContentParts;
+		const hasStructuredAssistantContent = hasAssistantContentParts(
+			renderedAssistantContentParts,
+		);
+		const hasRenderableContent =
+			message.content.trim().length > 0 || hasStructuredAssistantContent;
+		const showGenericStreamingStatus =
+			isStreaming && actions.length === 0 && !hasStructuredAssistantContent;
 
 		const messageError = useMemo(() => {
-			const metadata = message.metadata as MessageMetadata | undefined;
 			return metadata?.error;
-		}, [message.metadata]);
+		}, [metadata]);
 
 		const agentFlowName = useMemo(() => {
-			const metadata = message.metadata as MessageMetadata | undefined;
 			return metadata?.agentFlowName;
-		}, [message.metadata]);
+		}, [metadata]);
 
 		const executionLabel = useMemo(() => {
 			if (!executeState?.node) return "";
@@ -170,19 +200,20 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 				) : null}
 				{showMessageControls &&
 				actions.length > 0 &&
-				assistantContentParts.length === 0 ? (
+				!hasStructuredAssistantContent ? (
 					<div className="w-full">
 						<MessageActions actions={actions} />
 					</div>
 				) : null}
-				<Message key={message.id} from={message.role}>
-					<MessageContent
-						className={cn(
-							"relative",
-							assistantContentParts.length > 0 &&
-								"group-[.is-assistant]:overflow-visible group-[.is-assistant]:rounded-none group-[.is-assistant]:border-0 group-[.is-assistant]:bg-transparent group-[.is-assistant]:px-0 group-[.is-assistant]:py-0 group-[.is-assistant]:shadow-none",
-						)}
-					>
+				{hasRenderableContent || showGenericStreamingStatus ? (
+					<Message key={message.id} from={message.role}>
+						<MessageContent
+							className={cn(
+								"relative",
+								hasStructuredAssistantContent &&
+									"group-[.is-assistant]:overflow-visible group-[.is-assistant]:rounded-none group-[.is-assistant]:border-0 group-[.is-assistant]:bg-transparent group-[.is-assistant]:px-0 group-[.is-assistant]:py-0 group-[.is-assistant]:shadow-none",
+							)}
+						>
 						{message.role === "user" && attachedDocuments.length > 0 && (
 							<MessageAttachedDocuments documents={attachedDocuments} />
 						)}
@@ -190,7 +221,6 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 							<MessageComplexImages complexContent={complexContent} />
 						)}
 						{!hasRenderableContent &&
-						assistantContentParts.length === 0 &&
 						isLastMessage &&
 						isStreaming ? (
 							<div className="py-2 flex items-center gap-2">
@@ -215,10 +245,10 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 											content={message.content}
 											isStreaming={isStreaming}
 										/>
-									) : assistantContentParts.length > 0 ? (
+									) : hasStructuredAssistantContent ? (
 										<>
 											<AssistantContentFlow
-												parts={assistantContentParts}
+												parts={renderedAssistantContentParts}
 												isStreaming={isStreaming}
 												suppressArtifactPreviews={
 													location.pathname === "/runtime"
@@ -280,8 +310,9 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 								</div>
 							</Suspense>
 						)}
-					</MessageContent>
-				</Message>
+						</MessageContent>
+					</Message>
+				) : null}
 			</div>
 		);
 	},
@@ -290,6 +321,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 			prev.message.id === next.message.id &&
 			prev.message.content === next.message.content &&
 			prev.message.complexContent === next.message.complexContent &&
+			prev.message.parts === next.message.parts &&
 			prev.message.metadata === next.message.metadata &&
 			prev.isLastMessage === next.isLastMessage &&
 			prev.isStreaming === next.isStreaming &&

--- a/src/main/modules/chat/components/MessageRenderer.tsx
+++ b/src/main/modules/chat/components/MessageRenderer.tsx
@@ -86,7 +86,9 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 
 		const assistantContentParts = useMemo<AssistantContentPart[]>(() => {
 			if (message.role !== "assistant" || !complexContent) return [];
-			const parts = (complexContent as unknown[]).filter(isAssistantContentPart);
+			const parts = (complexContent as unknown[]).filter(
+				isAssistantContentPart,
+			);
 			return parts.some((part) =>
 				part.type === "text" ? part.text.trim() : true,
 			)
@@ -214,102 +216,100 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(
 									"group-[.is-assistant]:overflow-visible group-[.is-assistant]:rounded-none group-[.is-assistant]:border-0 group-[.is-assistant]:bg-transparent group-[.is-assistant]:px-0 group-[.is-assistant]:py-0 group-[.is-assistant]:shadow-none",
 							)}
 						>
-						{message.role === "user" && attachedDocuments.length > 0 && (
-							<MessageAttachedDocuments documents={attachedDocuments} />
-						)}
-						{complexContent && (
-							<MessageComplexImages complexContent={complexContent} />
-						)}
-						{!hasRenderableContent &&
-						isLastMessage &&
-						isStreaming ? (
-							<div className="py-2 flex items-center gap-2">
-								<ThreeDotsLoader className="text-muted-foreground" />
-								{executionText ? (
-									<span className="text-muted-foreground animate-pulse">
-										{executionText}
-									</span>
-								) : null}
-							</div>
-						) : (
-							<Suspense
-								fallback={
-									<div className="py-2">
-										<ThreeDotsLoader className="text-muted-foreground" />
-									</div>
-								}
-							>
-								<div className="relative z-10">
-									{isUserMessage ? (
-										<UserMessageContent
-											content={message.content}
-											isStreaming={isStreaming}
-										/>
-									) : hasStructuredAssistantContent ? (
-										<>
-											<AssistantContentFlow
-												parts={renderedAssistantContentParts}
-												isStreaming={isStreaming}
-												suppressArtifactPreviews={
-													location.pathname === "/runtime"
-												}
-											/>
-											{messageError ? (
-												<MessageErrorNotice error={messageError} />
-											) : null}
-										</>
-									) : (
-										<>
-											<MessageContentWithArtifacts
-												content={message.content}
-												isStreaming={isStreaming}
-												suppressArtifactPreviews={
-													location.pathname === "/runtime"
-												}
-											/>
-											{messageError ? (
-												<MessageErrorNotice error={messageError} />
-											) : null}
-										</>
-									)}
-									{showGenericStreamingStatus && (
-										<>
-											<div className="mt-4 flex items-center gap-2">
-												<ThreeDotsLoader
-													className="text-muted-foreground"
-													size="sm"
-												/>
-												{executionText ? (
-													<span className="text-muted-foreground animate-pulse">
-														{executionText}
-													</span>
-												) : null}
-											</div>
-											<div
-												className="absolute -bottom-6 -left-6 -right-6 h-10 pointer-events-none rounded-b-lg z-0"
-												style={{
-													background:
-														"linear-gradient(to top, hsl(var(--background) / 0.2) 0%, hsl(var(--background) / 0.08) 55%, transparent 100%)",
-												}}
-											/>
-										</>
-									)}
-									{showMessageControls &&
-									!isStreaming &&
-									message.role === "assistant" &&
-									message.metadata &&
-									groupMessages &&
-									groupMessages.length > 0 ? (
-										<MessageFooter
-											message={message}
-											groupMessages={groupMessages}
-											selectedTopic={selectedTopic}
-											metadata={message.metadata as MessageMetadata}
-										/>
+							{message.role === "user" && attachedDocuments.length > 0 && (
+								<MessageAttachedDocuments documents={attachedDocuments} />
+							)}
+							{complexContent && (
+								<MessageComplexImages complexContent={complexContent} />
+							)}
+							{!hasRenderableContent && isLastMessage && isStreaming ? (
+								<div className="py-2 flex items-center gap-2">
+									<ThreeDotsLoader className="text-muted-foreground" />
+									{executionText ? (
+										<span className="text-muted-foreground animate-pulse">
+											{executionText}
+										</span>
 									) : null}
 								</div>
-							</Suspense>
-						)}
+							) : (
+								<Suspense
+									fallback={
+										<div className="py-2">
+											<ThreeDotsLoader className="text-muted-foreground" />
+										</div>
+									}
+								>
+									<div className="relative z-10">
+										{isUserMessage ? (
+											<UserMessageContent
+												content={message.content}
+												isStreaming={isStreaming}
+											/>
+										) : hasStructuredAssistantContent ? (
+											<>
+												<AssistantContentFlow
+													parts={renderedAssistantContentParts}
+													isStreaming={isStreaming}
+													suppressArtifactPreviews={
+														location.pathname === "/runtime"
+													}
+												/>
+												{messageError ? (
+													<MessageErrorNotice error={messageError} />
+												) : null}
+											</>
+										) : (
+											<>
+												<MessageContentWithArtifacts
+													content={message.content}
+													isStreaming={isStreaming}
+													suppressArtifactPreviews={
+														location.pathname === "/runtime"
+													}
+												/>
+												{messageError ? (
+													<MessageErrorNotice error={messageError} />
+												) : null}
+											</>
+										)}
+										{showGenericStreamingStatus && (
+											<>
+												<div className="mt-4 flex items-center gap-2">
+													<ThreeDotsLoader
+														className="text-muted-foreground"
+														size="sm"
+													/>
+													{executionText ? (
+														<span className="text-muted-foreground animate-pulse">
+															{executionText}
+														</span>
+													) : null}
+												</div>
+												<div
+													className="absolute -bottom-6 -left-6 -right-6 h-10 pointer-events-none rounded-b-lg z-0"
+													style={{
+														background:
+															"linear-gradient(to top, hsl(var(--background) / 0.2) 0%, hsl(var(--background) / 0.08) 55%, transparent 100%)",
+													}}
+												/>
+											</>
+										)}
+										{showMessageControls &&
+										!isStreaming &&
+										message.role === "assistant" &&
+										message.metadata &&
+										groupMessages &&
+										groupMessages.length > 0 ? (
+											<MessageFooter
+												message={message}
+												groupMessages={groupMessages}
+												selectedTopic={selectedTopic}
+												metadata={message.metadata as MessageMetadata}
+											/>
+										) : null}
+									</div>
+								</Suspense>
+							)}
 						</MessageContent>
 					</Message>
 				) : null}

--- a/src/main/modules/chat/components/message/AssistantContentFlow.tsx
+++ b/src/main/modules/chat/components/message/AssistantContentFlow.tsx
@@ -1,9 +1,5 @@
 import React from "react";
-import type {
-	ComplexContent,
-	ComplexContentPartExecution,
-	ComplexContentPartTool,
-} from "@/types/chat";
+import type { ComplexContentPartExecution, ComplexContentPartTool } from "@/types/chat";
 import {
 	AssistantWorkflowPart,
 	AssistantWorkflowSummary,
@@ -18,9 +14,24 @@ export type AssistantContentPart =
 	| ComplexContentPartExecution;
 
 export const isAssistantContentPart = (
-	part: ComplexContent[number],
+	part: unknown,
 ): part is AssistantContentPart =>
-	part.type === "text" || part.type === "tool" || part.type === "execution";
+	!!part &&
+	typeof part === "object" &&
+	"type" in part &&
+	(part.type === "text" || part.type === "tool" || part.type === "execution");
+
+const isVisibleTimelinePart = (
+	part: AssistantContentPart,
+	index: number,
+	latestWorkflowIndex: number,
+): boolean => {
+	if (part.type === "tool") return !isWorkflowEvidencePart(part);
+	if (part.type === "execution") {
+		return part.state !== "complete" && index === latestWorkflowIndex;
+	}
+	return false;
+};
 
 export const AssistantContentFlow: React.FC<{
 	parts: AssistantContentPart[];
@@ -71,11 +82,26 @@ export const AssistantContentFlow: React.FC<{
 					<AssistantToolTimelinePart
 						key={`${part.type}-${part.id}-${index}`}
 						part={part}
+						connectsToPrevious={
+							parts
+								.slice(0, index)
+								.some((previous, previousIndex) =>
+									isVisibleTimelinePart(
+										previous,
+										previousIndex,
+										latestWorkflowIndex,
+									),
+								)
+						}
 						isLast={
 							!parts
 								.slice(index + 1)
-								.some(
-									(next) => next.type === "tool" || next.type === "execution",
+								.some((next, nextOffset) =>
+									isVisibleTimelinePart(
+										next,
+										index + nextOffset + 1,
+										latestWorkflowIndex,
+									),
 								)
 						}
 					/>

--- a/src/main/modules/chat/components/message/AssistantContentFlow.tsx
+++ b/src/main/modules/chat/components/message/AssistantContentFlow.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import type { ComplexContentPartExecution, ComplexContentPartTool } from "@/types/chat";
+import type {
+	ComplexContentPartExecution,
+	ComplexContentPartTool,
+} from "@/types/chat";
 import {
 	AssistantWorkflowPart,
 	AssistantWorkflowSummary,
@@ -82,17 +85,15 @@ export const AssistantContentFlow: React.FC<{
 					<AssistantToolTimelinePart
 						key={`${part.type}-${part.id}-${index}`}
 						part={part}
-						connectsToPrevious={
-							parts
-								.slice(0, index)
-								.some((previous, previousIndex) =>
-									isVisibleTimelinePart(
-										previous,
-										previousIndex,
-										latestWorkflowIndex,
-									),
-								)
-						}
+						connectsToPrevious={parts
+							.slice(0, index)
+							.some((previous, previousIndex) =>
+								isVisibleTimelinePart(
+									previous,
+									previousIndex,
+									latestWorkflowIndex,
+								),
+							)}
 						isLast={
 							!parts
 								.slice(index + 1)

--- a/src/main/modules/chat/components/message/AssistantToolTimelinePart.tsx
+++ b/src/main/modules/chat/components/message/AssistantToolTimelinePart.tsx
@@ -17,7 +17,8 @@ import {
 export const AssistantToolTimelinePart: React.FC<{
 	part: ComplexContentPartTool;
 	isLast: boolean;
-}> = ({ part, isLast }) => {
+	connectsToPrevious?: boolean;
+}> = ({ part, isLast, connectsToPrevious = false }) => {
 	const { t } = useTranslation("chat");
 	const [isOpen, setIsOpen] = useState(false);
 	const actionName = part.name;
@@ -34,11 +35,12 @@ export const AssistantToolTimelinePart: React.FC<{
 	return (
 		<div className="grid min-w-[34rem] max-w-full grid-cols-[1rem_minmax(0,1fr)] gap-2.5">
 			<div className="relative flex h-11 justify-center">
+				{connectsToPrevious ? (
+					<div className="absolute left-1/2 top-0 h-[1.25rem] w-px -translate-x-1/2 bg-border/70" />
+				) : null}
 				{!isLast ? (
 					<div className="absolute left-1/2 top-[1.375rem] h-[calc(100%+0.75rem)] w-px -translate-x-1/2 bg-border/70" />
-				) : (
-					<div className="absolute left-1/2 top-[1.375rem] h-8 w-px -translate-x-1/2 bg-gradient-to-b from-border/70 to-transparent" />
-				)}
+				) : null}
 				<span
 					className={cn(
 						"absolute top-[1.125rem] z-10 h-2 w-2 rounded-full border bg-background",

--- a/src/main/modules/chat/components/message/AssistantToolTimelinePart.tsx
+++ b/src/main/modules/chat/components/message/AssistantToolTimelinePart.tsx
@@ -9,6 +9,11 @@ import {
 import type { ComplexContentPartTool } from "@/types/chat";
 import { cn } from "@/lib/utils";
 import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/main/components/ui/collapsible";
+import {
 	getActionIcon,
 	ToolActionDetails,
 	translateActionName,
@@ -26,6 +31,11 @@ export const AssistantToolTimelinePart: React.FC<{
 	const Icon = getActionIcon(actionName);
 	const isRunning = part.state === "running";
 	const isError = part.state === "error";
+	const statusLabel = isRunning
+		? t("toolStatus.running")
+		: isError
+			? t("toolStatus.error")
+			: t("toolStatus.done");
 	const actionItem = {
 		name: part.name,
 		description: part.description,
@@ -33,17 +43,17 @@ export const AssistantToolTimelinePart: React.FC<{
 	};
 
 	return (
-		<div className="grid min-w-[34rem] max-w-full grid-cols-[1rem_minmax(0,1fr)] gap-2.5">
+		<div className="grid min-w-[34rem] max-w-full grid-cols-[1rem_minmax(0,1fr)] gap-2.5 animate-in fade-in-0 slide-in-from-top-1 duration-200 ease-out">
 			<div className="relative flex h-11 justify-center">
 				{connectsToPrevious ? (
-					<div className="absolute left-1/2 top-0 h-[1.25rem] w-px -translate-x-1/2 bg-border/70" />
+					<div className="absolute left-1/2 top-0 h-[1.25rem] w-px -translate-x-1/2 bg-border/70 transition-colors duration-200" />
 				) : null}
 				{!isLast ? (
-					<div className="absolute left-1/2 top-[1.375rem] h-[calc(100%+0.75rem)] w-px -translate-x-1/2 bg-border/70" />
+					<div className="absolute left-1/2 top-[1.375rem] h-[calc(100%+0.75rem)] w-px -translate-x-1/2 bg-border/70 transition-colors duration-200" />
 				) : null}
 				<span
 					className={cn(
-						"absolute top-[1.125rem] z-10 h-2 w-2 rounded-full border bg-background",
+						"absolute top-[1.125rem] z-10 h-2 w-2 rounded-full border bg-background transition-all duration-200 ease-out",
 						isError
 							? "border-destructive bg-destructive"
 							: isRunning
@@ -53,51 +63,58 @@ export const AssistantToolTimelinePart: React.FC<{
 				/>
 			</div>
 			<div className="min-w-0">
-				<button
-					type="button"
-					className={cn(
-						"flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors",
-						isOpen ? "bg-muted/35" : "hover:bg-muted/20",
-					)}
-					onClick={() => setIsOpen((value) => !value)}
-				>
-					<span
+				<Collapsible open={isOpen} onOpenChange={setIsOpen}>
+					<CollapsibleTrigger asChild>
+						<button
+							type="button"
+							className={cn(
+								"group/tool flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-[background-color,box-shadow,transform] duration-200 ease-out hover:bg-muted/20 active:scale-[0.995]",
+								isOpen && "bg-muted/35 shadow-sm",
+							)}
+						>
+							<span
+								className={cn(
+									"flex h-7 w-7 shrink-0 items-center justify-center rounded-md border bg-background/70 transition-[background-color,border-color,color,transform] duration-200 ease-out group-hover/tool:scale-105",
+									isError
+										? "border-destructive/25 text-destructive"
+										: isRunning
+											? "border-primary/25 text-primary"
+											: "border-border/60 text-muted-foreground",
+								)}
+							>
+								<Icon className="h-4 w-4" />
+							</span>
+							<span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground transition-colors duration-200">
+								{title}
+							</span>
+							<span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground transition-colors duration-200">
+								{isRunning ? (
+									<Loader2 className="h-3.5 w-3.5 animate-spin" />
+								) : isError ? (
+									<AlertTriangle className="h-3.5 w-3.5 text-destructive" />
+								) : (
+									<CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+								)}
+								{statusLabel}
+							</span>
+							<ChevronDown
+								className={cn(
+									"h-4 w-4 shrink-0 text-muted-foreground transition-[transform,color] duration-200 ease-out",
+									isOpen && "rotate-180 text-foreground",
+								)}
+							/>
+						</button>
+					</CollapsibleTrigger>
+					<CollapsibleContent
 						className={cn(
-							"flex h-7 w-7 shrink-0 items-center justify-center rounded-md border bg-background/70",
-							isError
-								? "border-destructive/25 text-destructive"
-								: isRunning
-									? "border-primary/25 text-primary"
-									: "border-border/60 text-muted-foreground",
+							"overflow-hidden text-sm outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1 duration-200 ease-out",
 						)}
 					>
-						<Icon className="h-4 w-4" />
-					</span>
-					<span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-						{title}
-					</span>
-					<span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
-						{isRunning ? (
-							<Loader2 className="h-3.5 w-3.5 animate-spin" />
-						) : isError ? (
-							<AlertTriangle className="h-3.5 w-3.5 text-destructive" />
-						) : (
-							<CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
-						)}
-						{isRunning ? "Running" : isError ? "Error" : "Done"}
-					</span>
-					<ChevronDown
-						className={cn(
-							"h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-							isOpen && "rotate-180 text-foreground",
-						)}
-					/>
-				</button>
-				{isOpen ? (
-					<div className="mt-2 border-l border-border/60 pl-3 text-sm">
-						<ToolActionDetails item={actionItem} isOpen={isOpen} />
-					</div>
-				) : null}
+						<div className="mt-2 rounded-lg border border-border/60 bg-background/80 p-3 shadow-sm">
+							<ToolActionDetails item={actionItem} isOpen={isOpen} />
+						</div>
+					</CollapsibleContent>
+				</Collapsible>
 			</div>
 		</div>
 	);

--- a/src/main/modules/chat/components/message/AssistantWorkflow.tsx
+++ b/src/main/modules/chat/components/message/AssistantWorkflow.tsx
@@ -19,6 +19,7 @@ import type {
 import { DEFAULT_FLOW_STEPS } from "@/services/flows/flow-builder-catalog";
 import { cn } from "@/lib/utils";
 import { ToolActionDetails } from "../MessageActions";
+import { translateCommonKey } from "../../utils/i18n-helpers";
 
 const FLOW_STEP_BY_NAME = new Map(
 	DEFAULT_FLOW_STEPS.map((step) => [step.name, step]),
@@ -35,14 +36,6 @@ const humanizeStepName = (name: string): string =>
 const getCatalogStep = (part: ComplexContentPartExecution) =>
 	FLOW_STEP_BY_NAME.get(getExecutionActionName(part));
 
-const translateCommonKey = (
-	key: string | undefined,
-	t: ReturnType<typeof useTranslation>["t"],
-): string | undefined => {
-	if (!key) return undefined;
-	const translated = t(key, { ns: "common", defaultValue: "" });
-	return translated || undefined;
-};
 
 export const getWorkflowLabel = (
 	part: ComplexContentPartExecution,

--- a/src/main/modules/chat/components/message/AssistantWorkflow.tsx
+++ b/src/main/modules/chat/components/message/AssistantWorkflow.tsx
@@ -36,7 +36,6 @@ const humanizeStepName = (name: string): string =>
 const getCatalogStep = (part: ComplexContentPartExecution) =>
 	FLOW_STEP_BY_NAME.get(getExecutionActionName(part));
 
-
 export const getWorkflowLabel = (
 	part: ComplexContentPartExecution,
 	t: ReturnType<typeof useTranslation>["t"],

--- a/src/main/modules/chat/components/message/AssistantWorkflow.tsx
+++ b/src/main/modules/chat/components/message/AssistantWorkflow.tsx
@@ -234,7 +234,7 @@ export const AssistantWorkflowSummary: React.FC<{
 				/>
 			</button>
 			{isOpen ? (
-				<div className="mt-2 space-y-2 border-l border-border/55 pl-3">
+				<div className="mt-2 space-y-2 pl-3">
 					{parts.map((part, index) => (
 						<div
 							key={`${part.id}-${index}`}

--- a/src/main/modules/chat/components/message/AssistantWorkflow.tsx
+++ b/src/main/modules/chat/components/message/AssistantWorkflow.tsx
@@ -35,6 +35,15 @@ const humanizeStepName = (name: string): string =>
 const getCatalogStep = (part: ComplexContentPartExecution) =>
 	FLOW_STEP_BY_NAME.get(getExecutionActionName(part));
 
+const translateCommonKey = (
+	key: string | undefined,
+	t: ReturnType<typeof useTranslation>["t"],
+): string | undefined => {
+	if (!key) return undefined;
+	const translated = t(key, { ns: "common", defaultValue: "" });
+	return translated || undefined;
+};
+
 export const getWorkflowLabel = (
 	part: ComplexContentPartExecution,
 	t: ReturnType<typeof useTranslation>["t"],
@@ -46,7 +55,7 @@ export const getWorkflowLabel = (
 			? catalogStep.metadata.nameKey
 			: undefined;
 	const displayName =
-		(nameKey ? t(nameKey, { ns: "common" }) : undefined) ||
+		translateCommonKey(nameKey, t) ||
 		(typeof catalogStep?.metadata?.displayName === "string"
 			? catalogStep.metadata.displayName
 			: undefined);
@@ -102,7 +111,7 @@ const getWorkflowDescription = (
 			? catalogStep.metadata.descriptionKey
 			: undefined;
 	const description =
-		(descriptionKey ? t(descriptionKey, { ns: "common" }) : undefined) ||
+		translateCommonKey(descriptionKey, t) ||
 		(typeof catalogStep?.metadata?.description === "string"
 			? catalogStep.metadata.description
 			: undefined);

--- a/src/main/modules/chat/components/message/ChatImagePart.tsx
+++ b/src/main/modules/chat/components/message/ChatImagePart.tsx
@@ -1,30 +1,41 @@
-import React, { useState, useEffect } from "react";
-import type { ComplexContent, ComplexContentPartImage } from "@/types/chat";
+import React from "react";
+import type { ComplexContent, ComplexContentPartImageUrl } from "@/types/chat";
 import { documentFileSystemService } from "@/services/filesystem/document-filesystem";
 
-export const ChatImagePart: React.FC<{ part: ComplexContentPartImage }> = ({
+export const ChatImagePart: React.FC<{ part: ComplexContentPartImageUrl }> = ({
 	part,
 }) => {
-	const [dataUri, setDataUri] = useState<string | null>(null);
+	const [resolvedUrl, setResolvedUrl] = React.useState(part.image_url.url);
+	const url = part.image_url.url;
 
-	useEffect(() => {
-		let cancelled = false;
+	React.useEffect(() => {
+		let mounted = true;
+		const mimeType = part.image_url.mimeType;
+
+		if (!url || url.startsWith("data:") || !mimeType) {
+			setResolvedUrl(url);
+			return;
+		}
+
 		documentFileSystemService
-			.readFileAsBase64(part.path, part.mimeType)
-			.then((uri) => {
-				if (!cancelled) setDataUri(uri);
+			.readFileAsBase64(url, mimeType)
+			.then((dataUrl) => {
+				if (mounted) setResolvedUrl(dataUrl);
 			})
-			.catch(() => {});
-		return () => {
-			cancelled = true;
-		};
-	}, [part.path, part.mimeType]);
+			.catch(() => {
+				if (mounted) setResolvedUrl(url);
+			});
 
-	if (!dataUri) return null;
+		return () => {
+			mounted = false;
+		};
+	}, [part.image_url.mimeType, url]);
+
+	if (!url) return null;
 
 	return (
 		<img
-			src={dataUri}
+			src={resolvedUrl}
 			alt=""
 			className="max-h-48 rounded-md object-contain border border-border mt-1"
 		/>
@@ -35,8 +46,8 @@ export const MessageComplexImages: React.FC<{
 	complexContent: ComplexContent;
 }> = ({ complexContent }) => {
 	const imageParts = complexContent.filter(
-		(p) => p.type === "image",
-	) as ComplexContentPartImage[];
+		(p) => p.type === "image_url",
+	) as ComplexContentPartImageUrl[];
 	if (imageParts.length === 0) return null;
 
 	return (

--- a/src/main/modules/chat/components/message/message-parts-adapter.ts
+++ b/src/main/modules/chat/components/message/message-parts-adapter.ts
@@ -1,0 +1,166 @@
+import type {
+	AssistantExecutionPart,
+	ComplexContentPartTool,
+	MessageParts,
+} from "@/types/chat";
+import type { ChatCompletionMessageToolCall } from "@/types/openai";
+import type { AssistantContentPart } from "./AssistantContentFlow";
+
+type ExecuteState = {
+	node: string;
+	metadata?: Record<string, unknown>;
+};
+
+const parseToolContent = (content: unknown): Record<string, unknown> | null => {
+	if (typeof content !== "string") return null;
+	try {
+		const parsed = JSON.parse(content);
+		return parsed && typeof parsed === "object"
+			? (parsed as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+};
+
+const stringifyToolContent = (content: unknown): string => {
+	if (typeof content === "string") return content;
+	if (content == null) return "";
+	return JSON.stringify(content, null, 2);
+};
+
+const getExecutionId = (event: ExecuteState): string =>
+	(typeof event.metadata?.tool_call_id === "string" &&
+		event.metadata.tool_call_id) ||
+	(typeof event.metadata?.tool === "string" && event.metadata.tool) ||
+	event.node;
+
+const isToolExecution = (event: ExecuteState): boolean =>
+	typeof event.metadata?.tool === "string" ||
+	typeof event.metadata?.tool_call_id === "string";
+
+const findToolCall = (
+	toolCallsById: Map<string, ChatCompletionMessageToolCall>,
+	toolCallId: string,
+): ChatCompletionMessageToolCall | undefined => toolCallsById.get(toolCallId);
+
+const buildToolPart = (
+	toolCallId: string,
+	content: unknown,
+	toolCall: ChatCompletionMessageToolCall | undefined,
+): ComplexContentPartTool => {
+	const parsedContent = parseToolContent(content);
+	const name =
+		toolCall?.function.name ||
+		(typeof parsedContent?.actionType === "string"
+			? parsedContent.actionType
+			: toolCallId);
+	const description = stringifyToolContent(content);
+	return {
+		type: "tool",
+		id: toolCallId,
+		name,
+		description,
+		metadata: {
+			tool: name,
+			tool_call_id: toolCallId,
+			...(toolCall ? { tool_call: toolCall } : {}),
+			...(parsedContent ?? {}),
+		},
+		state:
+			description.toLowerCase().startsWith("error") ||
+			typeof parsedContent?.error === "string" ||
+			parsedContent?.success === false
+				? "error"
+				: "complete",
+	};
+};
+
+const buildRunningToolPart = (event: ExecuteState): ComplexContentPartTool => {
+	const tool =
+		typeof event.metadata?.tool === "string" ? event.metadata.tool : event.node;
+	const toolCallId =
+		typeof event.metadata?.tool_call_id === "string"
+			? event.metadata.tool_call_id
+			: getExecutionId(event);
+	return {
+		type: "tool",
+		id: toolCallId,
+		name: tool,
+		description: "",
+		metadata: {
+			...(event.metadata ?? {}),
+			tool,
+			tool_call_id: toolCallId,
+		},
+		state: "running",
+	};
+};
+
+const buildRunningExecutionPart = (
+	event: ExecuteState,
+): AssistantExecutionPart => ({
+	type: "execution",
+	id: getExecutionId(event),
+	node: event.node,
+	metadata: event.metadata,
+	state: "running",
+});
+
+export const buildAssistantContentParts = ({
+	parts,
+	executions,
+	executeState,
+}: {
+	parts: MessageParts | null | undefined;
+	executions?: AssistantExecutionPart[];
+	executeState?: ExecuteState;
+}): AssistantContentPart[] => {
+	const contentParts: AssistantContentPart[] = [...(executions ?? [])];
+	const toolCallsById = new Map<string, ChatCompletionMessageToolCall>();
+	const completedToolCallIds = new Set<string>();
+
+	for (const part of parts ?? []) {
+		if (part.role === "assistant") {
+			for (const toolCall of part.tool_calls ?? []) {
+				toolCallsById.set(toolCall.id, toolCall);
+			}
+			if (typeof part.content === "string" && part.content.trim()) {
+				contentParts.push({ type: "text", text: part.content });
+			}
+			continue;
+		}
+
+		if (part.role === "tool") {
+			completedToolCallIds.add(part.tool_call_id);
+			contentParts.push(
+				buildToolPart(
+					part.tool_call_id,
+					part.content,
+					findToolCall(toolCallsById, part.tool_call_id),
+				),
+			);
+		}
+	}
+
+	if (executeState) {
+		if (isToolExecution(executeState)) {
+			const runningTool = buildRunningToolPart(executeState);
+			if (!completedToolCallIds.has(runningTool.id)) {
+				contentParts.push(runningTool);
+			}
+		} else {
+			contentParts.push(buildRunningExecutionPart(executeState));
+		}
+	}
+
+	return contentParts;
+};
+
+export const hasAssistantContentParts = (
+	parts: AssistantContentPart[],
+): boolean =>
+	parts.some((part) => {
+		if (part.type === "text") return part.text.trim().length > 0;
+		return true;
+	});

--- a/src/main/modules/chat/hooks/use-chat.ts
+++ b/src/main/modules/chat/hooks/use-chat.ts
@@ -58,9 +58,7 @@ const cloneActions = (
 const cloneComplexContent = (
 	complexContent: ComplexContent | null | undefined,
 ): ComplexContent | null =>
-	complexContent
-		? complexContent.map((part) => ({ ...part }))
-		: null;
+	complexContent ? complexContent.map((part) => ({ ...part })) : null;
 
 const pickResultMetadata = (
 	metadata: Record<string, unknown> | undefined,
@@ -469,10 +467,7 @@ export const useChat = (model: string) => {
 								? {
 										...prev,
 										executeState: event,
-										executions: addStreamingExecution(
-											prev.executions,
-											event,
-										),
+										executions: addStreamingExecution(prev.executions, event),
 									}
 								: null,
 						);

--- a/src/main/modules/chat/hooks/use-chat.ts
+++ b/src/main/modules/chat/hooks/use-chat.ts
@@ -7,6 +7,8 @@ import type {
 	ChatStatus,
 	ComplexContent,
 	AttachedDocumentRef,
+	AssistantExecutionPart,
+	MessageParts,
 } from "@/types/chat";
 import { logError, logInfo } from "@/utils/logger";
 import { serviceManager } from "@/services";
@@ -24,12 +26,14 @@ import {
 	extractDocumentText,
 	formatDocumentBlock,
 } from "@/main/modules/chat/utils/extract-document-text";
-import type { ChatCompletionMessageToolCall } from "@/types/openai";
+import { cloneMessageParts } from "@/services/chat/message-parts";
+import { isAbortError } from "@/utils/abort";
 
 export interface InProgressMessage {
 	id: string;
 	content: string;
 	complexContent: ComplexContent | null;
+	parts: MessageParts | null;
 	actions: Array<{
 		id: string;
 		name: string;
@@ -40,6 +44,7 @@ export interface InProgressMessage {
 		node: string;
 		metadata?: Record<string, unknown>;
 	};
+	executions?: AssistantExecutionPart[];
 }
 
 const cloneActions = (
@@ -50,25 +55,71 @@ const cloneActions = (
 		metadata: { ...action.metadata },
 	}));
 
-const cloneToolCalls = (
-	toolCalls: ChatCompletionMessageToolCall[] | undefined,
-): ChatCompletionMessageToolCall[] | undefined =>
-	toolCalls?.map((toolCall) => ({
-		...toolCall,
-		function: { ...toolCall.function },
-	}));
-
 const cloneComplexContent = (
 	complexContent: ComplexContent | null | undefined,
 ): ComplexContent | null =>
 	complexContent
-		? complexContent.map((part) => ({
-				...part,
-				...("metadata" in part && part.metadata
-					? { metadata: { ...part.metadata } }
-					: {}),
-			}))
+		? complexContent.map((part) => ({ ...part }))
 		: null;
+
+const pickResultMetadata = (
+	metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> => {
+	if (!metadata) return {};
+
+	const allowedKeys = [
+		"provider",
+		"timeToAnswer",
+		"tokensPerSecond",
+		"estimatedTokens",
+		"usage",
+		"executions",
+	] as const;
+
+	return Object.fromEntries(
+		allowedKeys
+			.filter((key) => key in metadata)
+			.map((key) => [key, metadata[key]]),
+	);
+};
+
+const getExecutionPartId = (event: {
+	node: string;
+	metadata?: Record<string, unknown>;
+}): string =>
+	(typeof event.metadata?.tool_call_id === "string" &&
+		event.metadata.tool_call_id) ||
+	(typeof event.metadata?.tool === "string" && event.metadata.tool) ||
+	event.node;
+
+const isToolExecution = (event: {
+	metadata?: Record<string, unknown>;
+}): boolean =>
+	typeof event.metadata?.tool === "string" ||
+	typeof event.metadata?.tool_call_id === "string";
+
+const addStreamingExecution = (
+	executions: AssistantExecutionPart[] | undefined,
+	event: { node: string; metadata?: Record<string, unknown> },
+): AssistantExecutionPart[] => {
+	if (isToolExecution(event)) return executions ?? [];
+
+	const completed = (executions ?? []).map((part) =>
+		part.state === "running" ? { ...part, state: "complete" as const } : part,
+	);
+	const next: AssistantExecutionPart = {
+		type: "execution",
+		id: getExecutionPartId(event),
+		node: event.node,
+		metadata: event.metadata,
+		state: "running",
+	};
+	const existingIndex = completed.findIndex((part) => part.id === next.id);
+	if (existingIndex === -1) return [...completed, next];
+	const copy = [...completed];
+	copy[existingIndex] = next;
+	return copy;
+};
 
 export const useChat = (model: string) => {
 	const [inputValue, setInputValue] = useState("");
@@ -202,6 +253,7 @@ export const useChat = (model: string) => {
 		let assistantMessage: Message | null = null;
 		let currentContent = "";
 		let currentComplexContent: ComplexContent | null = null;
+		let currentParts: MessageParts | null = null;
 
 		try {
 			// Separate document refs by kind
@@ -235,16 +287,26 @@ export const useChat = (model: string) => {
 			// Upload new images and merge with image document refs to build complexContent
 			let complexContent: ComplexContent | undefined;
 			const imageParts: Array<{
-				type: "image";
-				path: string;
-				mimeType: string;
+				type: "image_url";
+				image_url: {
+					url: string;
+					detail: "auto";
+					mimeType: string;
+				};
 			}> = [];
 
 			if (attachedImages.length > 0) {
 				const uploaded = await Promise.all(
 					attachedImages.map(async (file) => {
 						const path = await documentFileSystemService.uploadChatImage(file);
-						return { type: "image" as const, path, mimeType: file.type };
+						return {
+							type: "image_url" as const,
+							image_url: {
+								url: path,
+								detail: "auto" as const,
+								mimeType: file.type,
+							},
+						};
 					}),
 				);
 				imageParts.push(...uploaded);
@@ -253,9 +315,12 @@ export const useChat = (model: string) => {
 			if (imageRefs.length > 0) {
 				imageParts.push(
 					...imageRefs.map((ref) => ({
-						type: "image" as const,
-						path: ref.path,
-						mimeType: ref.mimeType,
+						type: "image_url" as const,
+						image_url: {
+							url: ref.path,
+							detail: "auto" as const,
+							mimeType: ref.mimeType,
+						},
 					})),
 				);
 			}
@@ -332,6 +397,7 @@ export const useChat = (model: string) => {
 				id: assistantMessage.id,
 				content: "",
 				complexContent: null,
+				parts: null,
 				actions: [],
 			});
 
@@ -375,15 +441,40 @@ export const useChat = (model: string) => {
 								: null,
 						);
 					},
+					onParts: (parts) => {
+						currentParts = cloneMessageParts(parts);
+						setInProgressMessage((prev) =>
+							prev
+								? {
+										...prev,
+										parts: currentParts,
+									}
+								: null,
+						);
+					},
 					onAction: (actions) => {
 						// Only update in-progress message, not the store
 						setInProgressMessage((prev) =>
-							prev ? { ...prev, actions: cloneActions(actions) } : null,
+							prev
+								? {
+										...prev,
+										actions: cloneActions(actions),
+									}
+								: null,
 						);
 					},
 					onExecuteStart: (event) => {
 						setInProgressMessage((prev) =>
-							prev ? { ...prev, executeState: event } : null,
+							prev
+								? {
+										...prev,
+										executeState: event,
+										executions: addStreamingExecution(
+											prev.executions,
+											event,
+										),
+									}
+								: null,
 						);
 					},
 					onError: (error) => {
@@ -393,28 +484,27 @@ export const useChat = (model: string) => {
 				controller.signal,
 			);
 
-			const hasStructuredToolParts = result.contentParts.some(
-				(part) => part.type === "tool",
-			);
-			const actionMetadata = hasStructuredToolParts
-				? {}
-				: {
-						actions: result.actions,
-						tool_calls: cloneToolCalls(result.toolCalls),
-					};
+			const actionMetadata = {
+				actions: result.actions,
+			};
+			const finalContent = result.parts?.length ? "" : result.content;
+			const finalComplexContent = result.parts?.length
+				? null
+				: cloneComplexContent(result.contentParts);
 
 			// Handle completion or failure after stream finishes
 			if (result.failed) {
 				const errorMessage =
 					result.errorMetadata?.message || result.error || "Chat failed";
 				const errorContent =
-					result.content ||
+					finalContent ||
 					"Sorry, I encountered an error processing your message.";
 				updateMessage(assistantMessage.id, {
 					content: errorContent,
-					complexContent: cloneComplexContent(result.contentParts),
+					complexContent: finalComplexContent,
+					parts: result.parts ?? null,
 					metadata: {
-						...(result.metadata ?? {}),
+						...pickResultMetadata(result.metadata),
 						...actionMetadata,
 						error: result.errorMetadata ?? {
 							message: errorMessage,
@@ -434,8 +524,9 @@ export const useChat = (model: string) => {
 					prev
 						? {
 								...prev,
-								content: result.content,
-								complexContent: cloneComplexContent(result.contentParts),
+								content: finalContent,
+								complexContent: finalComplexContent,
+								parts: result.parts ?? null,
 								actions: cloneActions(result.actions),
 							}
 						: null,
@@ -445,10 +536,11 @@ export const useChat = (model: string) => {
 				await new Promise((resolve) => setTimeout(resolve, 150));
 
 				updateMessage(assistantMessage.id, {
-					content: result.content,
-					complexContent: cloneComplexContent(result.contentParts),
+					content: finalContent,
+					complexContent: finalComplexContent,
+					parts: result.parts ?? null,
 					metadata: {
-						...(result.metadata ?? {}),
+						...pickResultMetadata(result.metadata),
 						...actionMetadata,
 						model,
 						...(agentFlowName && { agentFlowName }),
@@ -461,15 +553,21 @@ export const useChat = (model: string) => {
 			setStatus("ready");
 		} catch (error) {
 			// Check if error is due to user aborting the request
-			if (error instanceof Error && error.message === "Operation aborted") {
+			if (isAbortError(error)) {
 				logInfo("Chat request was stopped by user");
 				setStatus("ready");
 
 				// Save any partial content that was streamed before abort
 				if (assistantMessage && currentContent) {
+					const savedParts = currentParts as MessageParts | null;
+					const hasSavedParts =
+						Array.isArray(savedParts) && savedParts.length > 0;
 					updateMessage(assistantMessage.id, {
-						content: currentContent,
-						complexContent: cloneComplexContent(currentComplexContent),
+						content: hasSavedParts ? "" : currentContent,
+						complexContent: hasSavedParts
+							? null
+							: cloneComplexContent(currentComplexContent),
+						parts: savedParts,
 						metadata: {
 							actions: inProgressMessage?.actions || [],
 							...(agentFlowName && { agentFlowName }),
@@ -493,6 +591,7 @@ export const useChat = (model: string) => {
 				updateMessage(assistantMessage.id, {
 					content: currentContent || errorContent,
 					complexContent: cloneComplexContent(currentComplexContent),
+					parts: currentParts,
 					metadata: {
 						error: errorMetadata,
 						model,

--- a/src/main/modules/chat/hooks/use-chat.ts
+++ b/src/main/modules/chat/hooks/use-chat.ts
@@ -86,6 +86,9 @@ export const useChat = (model: string) => {
 	const selectedAgentFlowId = useChatStore(
 		(state) => state.selectedAgentFlowId,
 	);
+	const currentConversation = useChatStore(
+		(state) => state.currentConversation,
+	);
 	const availableAgents = useAgentConfigStore((state) => state.availableAgents);
 	const agentFlowName = availableAgents.find(
 		(a) => a.id === selectedAgentFlowId,
@@ -97,7 +100,7 @@ export const useChat = (model: string) => {
 		(state) => state.setSelectedAgentFlowId,
 	);
 	const addMessage = useChatStore((state) => state.addMessage);
-	const finalizeMessage = useChatStore((state) => state.finalizeMessage);
+	const updateMessage = useChatStore((state) => state.updateMessage);
 	const setLoading = useChatStore((state) => state.setLoading);
 	const ensureMainConversation = useChatStore(
 		(state) => state.ensureMainConversation,
@@ -199,18 +202,6 @@ export const useChat = (model: string) => {
 		let assistantMessage: Message | null = null;
 		let currentContent = "";
 		let currentComplexContent: ComplexContent | null = null;
-		const startTime = Date.now();
-		let provider = "unknown";
-
-		// Get current model provider
-		try {
-			const currentModel = await serviceManager.llmService.getCurrentModel();
-			if (currentModel?.provider) {
-				provider = currentModel.provider;
-			}
-		} catch (error) {
-			logError("Failed to get current model provider:", error);
-		}
 
 		try {
 			// Separate document refs by kind
@@ -355,6 +346,11 @@ export const useChat = (model: string) => {
 							? selectedTopic
 							: undefined,
 					agentFlowId: selectedAgentFlowId ?? undefined,
+					conversation: {
+						id: currentConversation?.id ?? userMessage.conversationId,
+						inProgressMessage: { id: assistantMessage.id },
+						agentFlowName: agentFlowName ?? undefined,
+					},
 					streamConfig: {
 						minWordsToStream: 5,
 						streamToolCallsImmediately: true,
@@ -397,18 +393,15 @@ export const useChat = (model: string) => {
 				controller.signal,
 			);
 
-			// Calculate timing and performance metrics
-			const endTime = Date.now();
-			const timeToAnswer = (endTime - startTime) / 1000; // in seconds
-
-			// Use actual token count from API if available, otherwise estimate (~4 chars per token)
-			const totalTokens =
-				result.usage?.total_tokens ?? Math.round(result.content.length / 4);
-			const outputTokens =
-				result.usage?.completion_tokens ??
-				Math.round(result.content.length / 4);
-			const tokensPerSecond =
-				timeToAnswer > 0 ? outputTokens / timeToAnswer : 0;
+			const hasStructuredToolParts = result.contentParts.some(
+				(part) => part.type === "tool",
+			);
+			const actionMetadata = hasStructuredToolParts
+				? {}
+				: {
+						actions: result.actions,
+						tool_calls: cloneToolCalls(result.toolCalls),
+					};
 
 			// Handle completion or failure after stream finishes
 			if (result.failed) {
@@ -417,21 +410,17 @@ export const useChat = (model: string) => {
 				const errorContent =
 					result.content ||
 					"Sorry, I encountered an error processing your message.";
-				await finalizeMessage(assistantMessage.id, {
+				updateMessage(assistantMessage.id, {
 					content: errorContent,
 					complexContent: cloneComplexContent(result.contentParts),
 					metadata: {
-						actions: result.actions,
-						tool_calls: cloneToolCalls(result.toolCalls),
+						...(result.metadata ?? {}),
+						...actionMetadata,
 						error: result.errorMetadata ?? {
 							message: errorMessage,
 							rawMessage: result.error || errorMessage,
 						},
-						model: model,
-						provider: provider,
-						timeToAnswer: timeToAnswer,
-						tokensPerSecond: tokensPerSecond,
-						estimatedTokens: totalTokens,
+						model,
 						...(agentFlowName && { agentFlowName }),
 					},
 				});
@@ -455,18 +444,13 @@ export const useChat = (model: string) => {
 				// Small delay to let React render the updated content
 				await new Promise((resolve) => setTimeout(resolve, 150));
 
-				// Finalize with final content and actions
-				await finalizeMessage(assistantMessage.id, {
+				updateMessage(assistantMessage.id, {
 					content: result.content,
 					complexContent: cloneComplexContent(result.contentParts),
 					metadata: {
-						actions: result.actions,
-						tool_calls: cloneToolCalls(result.toolCalls),
-						model: model,
-						provider: provider,
-						timeToAnswer: timeToAnswer,
-						tokensPerSecond: tokensPerSecond,
-						estimatedTokens: totalTokens,
+						...(result.metadata ?? {}),
+						...actionMetadata,
+						model,
 						...(agentFlowName && { agentFlowName }),
 					},
 				});
@@ -483,19 +467,15 @@ export const useChat = (model: string) => {
 
 				// Save any partial content that was streamed before abort
 				if (assistantMessage && currentContent) {
-					try {
-						await finalizeMessage(assistantMessage.id, {
-							content: currentContent,
-							complexContent: cloneComplexContent(currentComplexContent),
-							metadata: {
-								actions: inProgressMessage?.actions || [],
-								...(agentFlowName && { agentFlowName }),
-							},
-						});
-						logInfo("Saved partial content from stopped generation");
-					} catch (saveError) {
-						logError("Failed to save partial content:", saveError);
-					}
+					updateMessage(assistantMessage.id, {
+						content: currentContent,
+						complexContent: cloneComplexContent(currentComplexContent),
+						metadata: {
+							actions: inProgressMessage?.actions || [],
+							...(agentFlowName && { agentFlowName }),
+						},
+					});
+					logInfo("Saved partial content from stopped generation");
 				}
 
 				// Clear in-progress message
@@ -510,13 +490,12 @@ export const useChat = (model: string) => {
 			if (assistantMessage) {
 				const errorContent =
 					"Sorry, I encountered an error processing your message.";
-				await finalizeMessage(assistantMessage.id, {
+				updateMessage(assistantMessage.id, {
 					content: currentContent || errorContent,
 					complexContent: cloneComplexContent(currentComplexContent),
 					metadata: {
 						error: errorMetadata,
 						model,
-						provider,
 						...(agentFlowName && { agentFlowName }),
 					},
 				});
@@ -527,7 +506,6 @@ export const useChat = (model: string) => {
 					metadata: {
 						error: errorMetadata,
 						model,
-						provider,
 						...(agentFlowName && { agentFlowName }),
 					},
 				});

--- a/src/main/modules/chat/services/chat-service.ts
+++ b/src/main/modules/chat/services/chat-service.ts
@@ -1,21 +1,24 @@
 import { backgroundJob } from "@/services/background-jobs/background-job";
 import type {
 	ChatResult,
-	ConversationContext,
 	ChatStreamConfig,
 } from "@/services/background-jobs/handlers/process-chat";
 import type { JobErrorMetadata } from "@/services/background-jobs/handlers/error-metadata";
 import {
-	appendTextPart,
-	cloneContentParts,
-	completeRunningExecutionParts,
-	stripTransientExecutionParts,
-	upsertExecutionPart,
-	upsertToolParts,
-} from "@/services/chat/content-parts";
-import type { ComplexContent } from "@/types/chat";
+	cloneMessageParts,
+	MessagePartsAccumulator,
+} from "@/services/chat/message-parts";
+import {
+	accumulateChunkToolCalls,
+	createToolCallAccumulator,
+	getAccumulatedToolCalls,
+} from "@/services/chat/tool-call-accumulator";
 import type {
-	ChatCompletionChunkToolCall,
+	ComplexContent,
+	ConversationContext,
+	MessageParts,
+} from "@/types/chat";
+import type {
 	ChatCompletionMessageToolCall,
 	ChatCompletionTool,
 	ChatCompletionToolChoiceOption,
@@ -49,6 +52,7 @@ export interface ChatAction {
 export interface ChatStreamCallbacks {
 	onContent?: (content: string) => void;
 	onContentParts?: (parts: ComplexContent) => void;
+	onParts?: (parts: MessageParts) => void;
 	onAction?: (actions: ChatAction[]) => void;
 	onExecuteStart?: (event: {
 		node: string;
@@ -60,6 +64,7 @@ export interface ChatStreamCallbacks {
 export interface ChatStreamResult {
 	content: string;
 	contentParts: ComplexContent;
+	parts?: MessageParts;
 	actions: ChatAction[];
 	toolCalls?: ChatCompletionMessageToolCall[];
 	failed: boolean;
@@ -72,56 +77,6 @@ export interface ChatStreamResult {
 		total_tokens: number;
 	};
 }
-
-type ToolCallAccumulator = Map<
-	number,
-	{
-		id: string;
-		type: "function";
-		function: {
-			name: string;
-			arguments: string;
-		};
-	}
->;
-
-const accumulateChunkToolCalls = (
-	accumulator: ToolCallAccumulator,
-	toolCalls: ChatCompletionChunkToolCall[] | undefined,
-): void => {
-	if (!toolCalls?.length) {
-		return;
-	}
-
-	for (const toolCall of toolCalls) {
-		const existing = accumulator.get(toolCall.index);
-		if (existing) {
-			if (toolCall.id) {
-				existing.id = toolCall.id;
-			}
-			if (toolCall.function?.name) {
-				existing.function.name = toolCall.function.name;
-			}
-			if (toolCall.function?.arguments) {
-				existing.function.arguments += toolCall.function.arguments;
-			}
-			continue;
-		}
-
-		accumulator.set(toolCall.index, {
-			id: toolCall.id || `call_${toolCall.index}_${Date.now()}`,
-			type: "function",
-			function: {
-				name: toolCall.function?.name || "",
-				arguments: toolCall.function?.arguments || "",
-			},
-		});
-	}
-};
-
-const getAccumulatedToolCalls = (
-	accumulator: ToolCallAccumulator,
-): ChatCompletionMessageToolCall[] => Array.from(accumulator.values());
 
 const mergeActions = (
 	current: ChatAction[],
@@ -179,16 +134,6 @@ const getProgressErrorMetadata = (
 		message: typeof error === "string" ? error : fallbackMessage,
 		rawMessage: fallbackMessage,
 	};
-};
-
-const stripContentPartsMetadata = (
-	metadata: Extract<ChatResult, { type: "final" }>["metadata"],
-): Record<string, unknown> | undefined => {
-	if (!metadata) {
-		return undefined;
-	}
-	const { contentParts: _contentParts, ...rest } = metadata;
-	return rest;
 };
 
 export class ChatService {
@@ -269,11 +214,13 @@ export class ChatService {
 			let streamError = "";
 			let streamErrorMetadata: JobErrorMetadata | undefined;
 			let finalMetadata: Record<string, unknown> | undefined;
+			let parts: MessageParts | undefined;
 			let usage: ChatStreamResult["usage"];
-			const toolCallAccumulator: ToolCallAccumulator = new Map();
-			let contentParts: ComplexContent = [];
-			const emitContentParts = () => {
-				callbacks?.onContentParts?.(cloneContentParts(contentParts));
+			const toolCallAccumulator = createToolCallAccumulator();
+			const messagePartsAccumulator = new MessagePartsAccumulator();
+			const emitParts = () => {
+				const nextParts = cloneMessageParts(parts);
+				if (nextParts) callbacks?.onParts?.(nextParts);
 			};
 
 			if (!("stream" in result)) {
@@ -310,17 +257,17 @@ export class ChatService {
 					if (chatResult.type === "final") {
 						// Use the final content from the job result
 						currentContent = chatResult.content;
-						finalMetadata = stripContentPartsMetadata(chatResult.metadata);
+						finalMetadata = chatResult.metadata;
 						if (chatResult.metadata?.actions) {
 							actions.splice(
 								0,
 								actions.length,
 								...mergeActions(actions, chatResult.metadata.actions),
 							);
-							contentParts = upsertToolParts(contentParts, actions);
 						}
-						if (chatResult.metadata?.contentParts) {
-							contentParts = chatResult.metadata.contentParts as ComplexContent;
+						if (chatResult.parts) {
+							parts = chatResult.parts;
+							emitParts();
 						}
 						if (chatResult.metadata?.tool_calls?.length) {
 							for (const [
@@ -333,7 +280,6 @@ export class ChatService {
 						if (chatResult.metadata?.usage) {
 							usage = chatResult.metadata.usage;
 						}
-						emitContentParts();
 					}
 				}
 
@@ -345,20 +291,21 @@ export class ChatService {
 					const chatResult = progress.result as ChatResult;
 
 					if (chatResult.type === "chunk" && chatResult.chunk) {
+						messagePartsAccumulator.addChunk(chatResult.chunk);
+						parts = messagePartsAccumulator.toParts();
+						emitParts();
 						accumulateChunkToolCalls(
 							toolCallAccumulator,
 							chatResult.chunk.choices[0]?.delta?.tool_calls,
 						);
 						// Handle streaming content chunks
-						const content = chatResult.chunk.choices[0]?.delta?.content;
+						const delta = chatResult.chunk.choices[0]?.delta;
+						const isToolResultChunk =
+							delta?.role === "tool" || !!delta?.tool_call_id;
+						const content = isToolResultChunk ? "" : delta?.content;
 						if (content) {
 							currentContent += content;
-							contentParts = appendTextPart(
-								completeRunningExecutionParts(contentParts),
-								content,
-							);
 							callbacks?.onContent?.(currentContent);
-							emitContentParts();
 						}
 					} else if (chatResult.type === "action" && chatResult.actions) {
 						// Handle action updates
@@ -367,33 +314,29 @@ export class ChatService {
 							actions.length,
 							...mergeActions(actions, chatResult.actions),
 						);
-						contentParts = upsertToolParts(contentParts, chatResult.actions);
 						callbacks?.onAction?.([...actions]);
-						emitContentParts();
 					} else if (chatResult.type === "execute-start") {
 						const event = {
 							node: chatResult.node,
 							metadata: chatResult.metadata,
 						};
-						contentParts = upsertExecutionPart(contentParts, event);
 						callbacks?.onExecuteStart?.(event);
-						emitContentParts();
 					} else if (chatResult.type === "final") {
 						// Handle final content update (e.g., after citation step)
 						// This replaces the accumulated content with the final version
 						currentContent = chatResult.content;
-						finalMetadata = stripContentPartsMetadata(chatResult.metadata);
-						contentParts = completeRunningExecutionParts(contentParts);
+						finalMetadata = chatResult.metadata;
 						if (chatResult.metadata?.actions) {
 							actions.splice(
 								0,
 								actions.length,
 								...mergeActions(actions, chatResult.metadata.actions),
 							);
-							contentParts = upsertToolParts(contentParts, actions);
 						}
-						if (chatResult.metadata?.contentParts) {
-							contentParts = chatResult.metadata.contentParts as ComplexContent;
+						if (chatResult.parts) {
+							parts = chatResult.parts;
+						} else {
+							parts = messagePartsAccumulator.toParts();
 						}
 						if (chatResult.metadata?.tool_calls?.length) {
 							for (const [
@@ -406,22 +349,16 @@ export class ChatService {
 						// Notify with the final cited content
 						callbacks?.onContent?.(currentContent);
 						callbacks?.onAction?.([...actions]);
-						emitContentParts();
+						emitParts();
 					}
 				}
-			}
-
-			if (
-				currentContent &&
-				!contentParts.some((part) => part.type === "text")
-			) {
-				contentParts = appendTextPart(contentParts, currentContent);
 			}
 
 			// Return result
 			return {
 				content: currentContent,
-				contentParts: stripTransientExecutionParts(contentParts),
+				contentParts: [],
+				parts: parts ?? messagePartsAccumulator.toParts(),
 				actions,
 				toolCalls: getAccumulatedToolCalls(toolCallAccumulator),
 				failed: streamFailed,

--- a/src/main/modules/chat/services/chat-service.ts
+++ b/src/main/modules/chat/services/chat-service.ts
@@ -1,6 +1,7 @@
 import { backgroundJob } from "@/services/background-jobs/background-job";
 import type {
 	ChatResult,
+	ConversationContext,
 	ChatStreamConfig,
 } from "@/services/background-jobs/handlers/process-chat";
 import type { JobErrorMetadata } from "@/services/background-jobs/handlers/error-metadata";
@@ -35,6 +36,7 @@ export interface ChatServiceOptions {
 	tools?: ChatCompletionTool[];
 	tool_choice?: ChatCompletionToolChoiceOption;
 	parallel_tool_calls?: boolean;
+	conversation?: ConversationContext;
 }
 
 export interface ChatAction {
@@ -63,6 +65,7 @@ export interface ChatStreamResult {
 	failed: boolean;
 	error?: string;
 	errorMetadata?: JobErrorMetadata;
+	metadata?: Record<string, unknown>;
 	usage?: {
 		prompt_tokens: number;
 		completion_tokens: number;
@@ -178,6 +181,16 @@ const getProgressErrorMetadata = (
 	};
 };
 
+const stripContentPartsMetadata = (
+	metadata: Extract<ChatResult, { type: "final" }>["metadata"],
+): Record<string, unknown> | undefined => {
+	if (!metadata) {
+		return undefined;
+	}
+	const { contentParts: _contentParts, ...rest } = metadata;
+	return rest;
+};
+
 export class ChatService {
 	private static instance: ChatService;
 	private activeJobs = new Map<string, AbortController>();
@@ -210,6 +223,7 @@ export class ChatService {
 			tools,
 			tool_choice,
 			parallel_tool_calls,
+			conversation,
 		} = options;
 
 		const abortController = new AbortController();
@@ -240,6 +254,7 @@ export class ChatService {
 					tools,
 					tool_choice,
 					parallel_tool_calls,
+					conversation,
 					streamConfig: streamConfig || {
 						minWordsToStream: 5,
 						streamToolCallsImmediately: true,
@@ -253,6 +268,7 @@ export class ChatService {
 			let streamFailed = false;
 			let streamError = "";
 			let streamErrorMetadata: JobErrorMetadata | undefined;
+			let finalMetadata: Record<string, unknown> | undefined;
 			let usage: ChatStreamResult["usage"];
 			const toolCallAccumulator: ToolCallAccumulator = new Map();
 			let contentParts: ComplexContent = [];
@@ -294,6 +310,7 @@ export class ChatService {
 					if (chatResult.type === "final") {
 						// Use the final content from the job result
 						currentContent = chatResult.content;
+						finalMetadata = stripContentPartsMetadata(chatResult.metadata);
 						if (chatResult.metadata?.actions) {
 							actions.splice(
 								0,
@@ -365,6 +382,7 @@ export class ChatService {
 						// Handle final content update (e.g., after citation step)
 						// This replaces the accumulated content with the final version
 						currentContent = chatResult.content;
+						finalMetadata = stripContentPartsMetadata(chatResult.metadata);
 						contentParts = completeRunningExecutionParts(contentParts);
 						if (chatResult.metadata?.actions) {
 							actions.splice(
@@ -409,6 +427,7 @@ export class ChatService {
 				failed: streamFailed,
 				error: streamFailed ? streamError : undefined,
 				errorMetadata: streamFailed ? streamErrorMetadata : undefined,
+				metadata: finalMetadata,
 				usage,
 			};
 		} catch (error) {

--- a/src/main/modules/chat/utils/build-send-messages.ts
+++ b/src/main/modules/chat/utils/build-send-messages.ts
@@ -1,9 +1,8 @@
-import type { ChatMessage, ChatCompletionContentPart } from "@/types/openai";
 import type {
-	ComplexContent,
-	ComplexContentPartImage,
-	ComplexContentPartTool,
-} from "@/types/chat";
+	ChatMessage,
+	ChatCompletionContentPart,
+} from "@/types/openai";
+import type { ComplexContent, MessageParts } from "@/types/chat";
 import type { Message } from "@/services/database";
 import { documentFileSystemService } from "@/services/filesystem/document-filesystem";
 
@@ -29,21 +28,20 @@ function renderAction(a: StoredAction): string {
 }
 
 function buildAssistantContent(msg: Message): string {
-	const complexContent = msg.complexContent as
-		| ComplexContent
-		| null
-		| undefined;
-	if (complexContent && complexContent.length > 0) {
-		return complexContent
-			.map((part) => {
-				if (part.type === "text") return part.text;
-				if (part.type === "tool" && part.state !== "running") {
-					return renderAction(part as ComplexContentPartTool);
-				}
-				return "";
-			})
+	const complexContent = Array.isArray(msg.complexContent)
+		? (msg.complexContent as Array<{ type?: unknown; text?: unknown }>)
+		: null;
+	const complexText =
+		complexContent
+			?.map((part) => (part.type === "text" && typeof part.text === "string" ? part.text : ""))
 			.filter(Boolean)
-			.join("\n\n");
+			.join("\n\n") ?? "";
+	const hasLegacyTimelineParts =
+		complexContent?.some(
+			(part) => part.type === "tool" || part.type === "execution",
+		) ?? false;
+	if (hasLegacyTimelineParts || (!msg.content && complexText)) {
+		return complexText;
 	}
 
 	const metadata = msg.metadata as Record<string, unknown> | null;
@@ -57,24 +55,10 @@ function buildAssistantContent(msg: Message): string {
 	return content;
 }
 
-/** Convert a stored image part into an OpenAI image_url content part (base64 data URI). */
-async function resolveImagePart(
-	part: ComplexContentPartImage,
-): Promise<ChatCompletionContentPart> {
-	const dataUri = await documentFileSystemService.readFileAsBase64(
-		part.path,
-		part.mimeType,
-	);
-	return {
-		type: "image_url",
-		image_url: { url: dataUri, detail: "auto" },
-	};
-}
-
 /**
  * Build the OpenAI content value for a user message.
- * If the message has complexContent (multipart), resolve images to base64 data URIs
- * and return a content array. Otherwise return the plain string.
+ * If the message has complexContent, it is already stored as OpenAI-compatible
+ * content parts. Otherwise return the plain string.
  */
 async function buildUserContent(
 	msg: Message,
@@ -93,8 +77,22 @@ async function buildUserContent(
 			if (part.type === "text") {
 				return { type: "text", text: part.text };
 			}
-			if (part.type === "image") {
-				return resolveImagePart(part);
+			if (part.type === "image_url") {
+				const { url, detail = "auto", mimeType } = part.image_url;
+				if (url.startsWith("data:") || !mimeType) {
+					return {
+						type: "image_url",
+						image_url: { url, detail },
+					};
+				}
+				const dataUrl = await documentFileSystemService.readFileAsBase64(
+					url,
+					mimeType,
+				);
+				return {
+					type: "image_url",
+					image_url: { url: dataUrl, detail },
+				};
 			}
 			return { type: "text", text: "" };
 		}),
@@ -107,22 +105,28 @@ export async function buildSendMessages(
 	relevantMessages: Message[],
 ): Promise<ChatMessage[]> {
 	const filtered = relevantMessages.filter((msg) => msg.type !== "separator");
+	const built: ChatMessage[] = [];
 
-	return Promise.all(
-		filtered.map(async (msg): Promise<ChatMessage> => {
-			const role = msg.role as "system" | "user" | "assistant";
-			if (role === "system") {
-				return { role, content: msg.content };
-			}
-			if (role === "user") {
-				const content = await buildUserContent(msg);
-				return { role, content };
-			}
-			// Persisted assistant tool calls must not be replayed on later turns.
-			// OpenAI-compatible providers require matching tool result messages for
-			// every assistant tool call, but we store only the finalized assistant
-			// answer plus action summaries, not the raw tool-message chain.
-			return { role: "assistant", content: buildAssistantContent(msg) };
-		}),
-	);
+	for (const msg of filtered) {
+		const role = msg.role as "system" | "user" | "assistant";
+		if (role === "system") {
+			built.push({ role, content: msg.content });
+			continue;
+		}
+		if (role === "user") {
+			const content = await buildUserContent(msg);
+			built.push({ role, content });
+			continue;
+		}
+
+		const parts = msg.parts as MessageParts | null | undefined;
+		if (Array.isArray(parts) && parts.length > 0) {
+			built.push(...parts);
+			continue;
+		}
+
+		built.push({ role: "assistant", content: buildAssistantContent(msg) });
+	}
+
+	return built;
 }

--- a/src/main/modules/chat/utils/build-send-messages.ts
+++ b/src/main/modules/chat/utils/build-send-messages.ts
@@ -1,7 +1,4 @@
-import type {
-	ChatMessage,
-	ChatCompletionContentPart,
-} from "@/types/openai";
+import type { ChatMessage, ChatCompletionContentPart } from "@/types/openai";
 import type { ComplexContent, MessageParts } from "@/types/chat";
 import type { Message } from "@/services/database";
 import { documentFileSystemService } from "@/services/filesystem/document-filesystem";
@@ -33,7 +30,9 @@ function buildAssistantContent(msg: Message): string {
 		: null;
 	const complexText =
 		complexContent
-			?.map((part) => (part.type === "text" && typeof part.text === "string" ? part.text : ""))
+			?.map((part) =>
+				part.type === "text" && typeof part.text === "string" ? part.text : "",
+			)
 			.filter(Boolean)
 			.join("\n\n") ?? "";
 	const hasLegacyTimelineParts =

--- a/src/main/modules/chat/utils/build-send-messages.ts
+++ b/src/main/modules/chat/utils/build-send-messages.ts
@@ -33,7 +33,7 @@ function buildAssistantContent(msg: Message): string {
 		| ComplexContent
 		| null
 		| undefined;
-	if (complexContent?.some((part) => part.type === "tool")) {
+	if (complexContent && complexContent.length > 0) {
 		return complexContent
 			.map((part) => {
 				if (part.type === "text") return part.text;

--- a/src/main/modules/chat/utils/i18n-helpers.ts
+++ b/src/main/modules/chat/utils/i18n-helpers.ts
@@ -1,0 +1,10 @@
+import type { useTranslation } from "react-i18next";
+
+export const translateCommonKey = (
+	key: string | undefined,
+	t: ReturnType<typeof useTranslation>["t"],
+): string | undefined => {
+	if (!key) return undefined;
+	const translated = t(key, { ns: "common", defaultValue: "" });
+	return translated || undefined;
+};

--- a/src/main/modules/llm/hooks/use-model-operations.ts
+++ b/src/main/modules/llm/hooks/use-model-operations.ts
@@ -205,6 +205,12 @@ export function useModelOperations({
 			} catch (err) {
 				logError(`Error loading ${modelId}`, err);
 			} finally {
+				setDownloadProgress({
+					loaded: 0,
+					total: 0,
+					percent: 0,
+					text: "",
+				});
 				setLoading(false);
 			}
 		},

--- a/src/main/stores/chat.ts
+++ b/src/main/stores/chat.ts
@@ -54,7 +54,6 @@ interface ChatStore {
 	syncWithDB: () => Promise<void>;
 }
 
-
 const buildLatestGroupId = (previousSeparator: Message | null) =>
 	`group:latest:${previousSeparator?.id ?? "root"}`;
 

--- a/src/main/stores/chat.ts
+++ b/src/main/stores/chat.ts
@@ -7,6 +7,7 @@ import {
 } from "@/services/database/types";
 import { serviceManager } from "@/services";
 import { logError } from "@/utils/logger";
+import { sanitizeForJson } from "@/utils/sanitize-json";
 import { v4 } from "@/utils/uuid";
 import type { ChatMode } from "@/main/modules/chat/services/chat-service";
 
@@ -53,43 +54,6 @@ interface ChatStore {
 	syncWithDB: () => Promise<void>;
 }
 
-/**
- * Sanitize a value so it is safe to store in a Postgres jsonb column.
- * - undefined -> null (undefined is not valid JSON)
- * - Date -> ISO string
- * - BigInt -> string
- * - functions / symbols -> null
- * - circular references are broken (replaced with null)
- */
-function sanitizeForJson(value: unknown, seen = new WeakSet()): unknown {
-	if (value === undefined) return null;
-	if (value === null) return null;
-
-	const type = typeof value;
-	if (type === "string" || type === "number" || type === "boolean") {
-		return value;
-	}
-	if (type === "bigint") return value.toString();
-	if (type === "function" || type === "symbol") return null;
-
-	if (value instanceof Date) return value.toISOString();
-
-	if (Array.isArray(value)) {
-		return value.map((item) => sanitizeForJson(item, seen));
-	}
-
-	if (type === "object") {
-		if (seen.has(value as object)) return null;
-		seen.add(value as object);
-		const result: Record<string, unknown> = {};
-		for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-			result[k] = sanitizeForJson(v, seen);
-		}
-		return result;
-	}
-
-	return null;
-}
 
 const buildLatestGroupId = (previousSeparator: Message | null) =>
 	`group:latest:${previousSeparator?.id ?? "root"}`;

--- a/src/services/background-jobs/handlers/cron-actions/agent-chat.ts
+++ b/src/services/background-jobs/handlers/cron-actions/agent-chat.ts
@@ -183,22 +183,28 @@ const persistAgentChatRun = async (
 		);
 
 		await db.insert(schema.messages).values(
-			createMessage(conversationId, "assistant", result.content, {
-				topicId,
-				metadata: {
-					source: "cron",
-					actionType: ACTION_TYPE,
-					cronJobId: cronJob.id,
-					triggeredAt: now.toISOString(),
-					reason,
-					actions: result.metadata?.actions ?? [],
-					tool_calls: result.metadata?.tool_calls ?? [],
-					usage: result.metadata?.usage,
-					model: payload.model,
+			createMessage(
+				conversationId,
+				"assistant",
+				result.metadata?.contentParts ? "" : result.content,
+				{
+					topicId,
+					complexContent: result.metadata?.contentParts ?? null,
+					metadata: {
+						source: "cron",
+						actionType: ACTION_TYPE,
+						cronJobId: cronJob.id,
+						triggeredAt: now.toISOString(),
+						reason,
+						actions: result.metadata?.actions ?? [],
+						tool_calls: result.metadata?.tool_calls ?? [],
+						usage: result.metadata?.usage,
+						model: payload.model,
+					},
+					createdAt: new Date(now.getTime() + 2),
+					updatedAt: new Date(now.getTime() + 2),
 				},
-				createdAt: new Date(now.getTime() + 2),
-				updatedAt: new Date(now.getTime() + 2),
-			}),
+			),
 		);
 
 		await db

--- a/src/services/background-jobs/handlers/cron-actions/agent-chat.ts
+++ b/src/services/background-jobs/handlers/cron-actions/agent-chat.ts
@@ -2,7 +2,6 @@ import { eq, sql } from "drizzle-orm";
 import { serviceManager } from "@/services";
 import type { AgentChatCronPayload, Message } from "@/services/database/types";
 import type { ChatPayload, ChatResult } from "../process-chat";
-import type { ComplexContent } from "@/types/chat";
 import { handlerRegistry } from "../handler-registry";
 import { v4 } from "@/utils/uuid";
 import {
@@ -36,6 +35,7 @@ const createMessage = (
 		content,
 		type: options.type ?? "text",
 		complexContent: options.complexContent ?? null,
+		parts: options.parts ?? null,
 		topicId: options.topicId,
 		metadata: options.metadata ?? {},
 		createdAt: options.createdAt ?? new Date(),
@@ -183,17 +183,16 @@ const persistAgentChatRun = async (
 			}),
 		);
 
-		const cronContentParts = Array.isArray(result.metadata?.contentParts)
-			? (result.metadata.contentParts as ComplexContent)
-			: null;
+		const assistantParts = result.parts ?? null;
 		await db.insert(schema.messages).values(
 			createMessage(
 				conversationId,
 				"assistant",
-				cronContentParts ? "" : result.content,
+				assistantParts ? "" : result.content,
 				{
 					topicId,
-					complexContent: cronContentParts,
+					complexContent: null,
+					parts: assistantParts,
 					metadata: {
 						source: "cron",
 						actionType: ACTION_TYPE,
@@ -201,7 +200,6 @@ const persistAgentChatRun = async (
 						triggeredAt: now.toISOString(),
 						reason,
 						actions: result.metadata?.actions ?? [],
-						tool_calls: result.metadata?.tool_calls ?? [],
 						usage: result.metadata?.usage,
 						model: payload.model,
 					},

--- a/src/services/background-jobs/handlers/cron-actions/agent-chat.ts
+++ b/src/services/background-jobs/handlers/cron-actions/agent-chat.ts
@@ -2,6 +2,7 @@ import { eq, sql } from "drizzle-orm";
 import { serviceManager } from "@/services";
 import type { AgentChatCronPayload, Message } from "@/services/database/types";
 import type { ChatPayload, ChatResult } from "../process-chat";
+import type { ComplexContent } from "@/types/chat";
 import { handlerRegistry } from "../handler-registry";
 import { v4 } from "@/utils/uuid";
 import {
@@ -182,14 +183,17 @@ const persistAgentChatRun = async (
 			}),
 		);
 
+		const cronContentParts = Array.isArray(result.metadata?.contentParts)
+			? (result.metadata.contentParts as ComplexContent)
+			: null;
 		await db.insert(schema.messages).values(
 			createMessage(
 				conversationId,
 				"assistant",
-				result.metadata?.contentParts ? "" : result.content,
+				cronContentParts ? "" : result.content,
 				{
 					topicId,
-					complexContent: result.metadata?.contentParts ?? null,
+					complexContent: cronContentParts,
 					metadata: {
 						source: "cron",
 						actionType: ACTION_TYPE,

--- a/src/services/background-jobs/handlers/process-chat.ts
+++ b/src/services/background-jobs/handlers/process-chat.ts
@@ -15,17 +15,23 @@ import {
 	normalizeLangGraphStreamChunk,
 	type FlowAction,
 } from "@/services/flows/utils/langgraph-stream";
-import type { ComplexContent } from "@/types/chat";
+import type {
+	AssistantExecutionPart,
+	ComplexContent,
+	ConversationContext,
+	MessageParts,
+} from "@/types/chat";
 import { handlerRegistry } from "./handler-registry";
 import type { FoundationState } from "@/services/flows/graph/foundation/state";
 import {
-	appendTextPart,
-	completeRunningExecutionParts,
-	replaceTextParts,
-	stripTransientExecutionParts,
-	upsertExecutionPart,
-	upsertToolParts,
-} from "@/services/chat/content-parts";
+	MessagePartsAccumulator,
+	resolveMessageParts,
+} from "@/services/chat/message-parts";
+import {
+	accumulateChunkToolCalls,
+	createToolCallAccumulator,
+	type ToolCallAccumulator,
+} from "@/services/chat/tool-call-accumulator";
 import { chatFlowRegistry } from "@/services/flows/chat-flow-registry";
 import type { UnifiedFlowConfig } from "@/services/flows/interfaces/flow-config";
 import { buildDefaultFlowConfig } from "@/services/flows/build-flow-config";
@@ -43,18 +49,13 @@ import {
 	type JobErrorMetadata,
 } from "./error-metadata";
 import { sanitizeForJson } from "@/utils/sanitize-json";
+import { isAbortError } from "@/utils/abort";
 
 export interface ChatStreamConfig {
 	/** Minimum number of words to buffer before streaming (default: 5) */
 	minWordsToStream?: number;
 	/** Whether to stream tool calls immediately (default: true) */
 	streamToolCallsImmediately?: boolean;
-}
-
-export interface ConversationContext {
-	id: string;
-	inProgressMessage: { id: string };
-	agentFlowName?: string;
 }
 
 export interface ChatPayload {
@@ -84,6 +85,7 @@ export type ChatResult =
 	| {
 			type: "final";
 			content: string;
+			parts?: MessageParts;
 			metadata?: {
 				actions?: Array<{
 					id: string;
@@ -91,7 +93,7 @@ export type ChatResult =
 					description: string;
 					metadata: Record<string, unknown>;
 				}>;
-				contentParts?: ComplexContent;
+				executions?: AssistantExecutionPart[];
 				tool_calls?: ChatCompletionMessageToolCall[];
 				usage?: {
 					prompt_tokens: number;
@@ -181,18 +183,6 @@ type TokenUsage = {
 	total_tokens: number;
 };
 
-type ToolCallAccumulator = Map<
-	number,
-	{
-		id: string;
-		type: "function";
-		function: {
-			name: string;
-			arguments: string;
-		};
-	}
->;
-
 const RECALL_STEP_BY_TYPE: Record<RecallType, string> = {
 	smart: "context-smart-retrieve",
 	quick: "context-quick-retrieve",
@@ -219,44 +209,6 @@ function applyTopicRecallType(
 	};
 }
 
-const accumulateChunkToolCalls = (
-	accumulator: ToolCallAccumulator,
-	toolCalls: ChatCompletionChunkToolCall[] | undefined,
-): void => {
-	if (!toolCalls?.length) {
-		return;
-	}
-
-	for (const toolCall of toolCalls) {
-		const existing = accumulator.get(toolCall.index);
-		if (existing) {
-			if (toolCall.function?.name) {
-				existing.function.name = toolCall.function.name;
-			}
-			if (toolCall.function?.arguments) {
-				existing.function.arguments += toolCall.function.arguments;
-			}
-			if (toolCall.id) {
-				existing.id = toolCall.id;
-			}
-			continue;
-		}
-
-		accumulator.set(toolCall.index, {
-			id: toolCall.id || `call_${toolCall.index}_${Date.now()}`,
-			type: "function",
-			function: {
-				name: toolCall.function?.name || "",
-				arguments: toolCall.function?.arguments || "",
-			},
-		});
-	}
-};
-
-const getAccumulatedToolCalls = (
-	accumulator: ToolCallAccumulator,
-): ChatCompletionMessageToolCall[] => Array.from(accumulator.values());
-
 type FlowStreamDeps = {
 	jobId: string;
 	model: string;
@@ -264,6 +216,7 @@ type FlowStreamDeps = {
 	dependencies: ProcessDependencies;
 	streamBuffer: StreamBuffer;
 	getProgress: () => number;
+	onChunk?: (chunk: ChatCompletionChunk) => void;
 	onUsage?: (usage: TokenUsage) => void;
 	onToolCalls?: (toolCalls: ChatCompletionChunkToolCall[] | undefined) => void;
 };
@@ -281,8 +234,10 @@ type FlowCustomPayloadDeps = {
 	payload: unknown;
 	handleChunk: (chunk: ChatCompletionChunk) => Promise<void>;
 	handleActions: (actions: FlowAction[]) => void;
-	actions: FlowAction[];
-	contentParts: ComplexContent;
+	handleExecutionStart: (event: {
+		node: string;
+		metadata?: Record<string, unknown>;
+	}) => void;
 	dependencies: ProcessDependencies;
 	jobId: string;
 	executeStage: string;
@@ -297,9 +252,19 @@ type FlowRuntimeDeps = {
 	dependencies: ProcessDependencies;
 	streamBuffer: StreamBuffer;
 	actions: FlowAction[];
+	messagePartsAccumulator: MessagePartsAccumulator;
 	toolCallAccumulator: ToolCallAccumulator;
 	addUsage: (usage: TokenUsage) => void;
 	getProgress: () => number;
+};
+
+type FlowStreamRunDeps = FlowRuntimeDeps & {
+	stream: AsyncIterable<unknown>;
+	executeStage: string;
+	handleExecutionStart: (event: {
+		node: string;
+		metadata?: Record<string, unknown>;
+	}) => void;
 };
 
 type AssistantMessageFinalization = {
@@ -310,7 +275,7 @@ type AssistantMessageFinalization = {
 	startTime: number;
 	usage?: TokenUsage;
 	actions: ChatResultFinalAction[];
-	toolCalls: ChatCompletionMessageToolCall[];
+	executions: AssistantExecutionPart[];
 	error?: JobErrorMetadata;
 };
 
@@ -318,6 +283,7 @@ type AssistantMessagePersistence = {
 	conversation: ConversationContext;
 	content: string;
 	complexContent: ComplexContent | null;
+	parts: MessageParts | null;
 	metadata: AssistantMessageMetadata;
 };
 
@@ -328,7 +294,7 @@ type AssistantMessageMetadata = {
 	tokensPerSecond: number;
 	estimatedTokens: number;
 	actions?: ChatResultFinalAction[];
-	tool_calls?: ChatCompletionMessageToolCall[];
+	executions?: AssistantExecutionPart[];
 	usage?: TokenUsage;
 	agentFlowName?: string;
 	error?: JobErrorMetadata;
@@ -346,6 +312,52 @@ const normalizeActions = (actions: FlowAction[]): ChatResultFinalAction[] =>
 		metadata: action.metadata,
 	}));
 
+const getExecutionPartId = (event: {
+	node: string;
+	metadata?: Record<string, unknown>;
+}): string =>
+	(typeof event.metadata?.tool_call_id === "string" &&
+		event.metadata.tool_call_id) ||
+	(typeof event.metadata?.tool === "string" && event.metadata.tool) ||
+	event.node;
+
+const isToolExecution = (event: {
+	metadata?: Record<string, unknown>;
+}): boolean =>
+	typeof event.metadata?.tool === "string" ||
+	typeof event.metadata?.tool_call_id === "string";
+
+const addExecutionPart = (
+	parts: AssistantExecutionPart[],
+	event: { node: string; metadata?: Record<string, unknown> },
+): AssistantExecutionPart[] => {
+	if (isToolExecution(event)) return parts;
+
+	const completed = parts.map((part) =>
+		part.state === "running" ? { ...part, state: "complete" as const } : part,
+	);
+	const id = getExecutionPartId(event);
+	const next: AssistantExecutionPart = {
+		type: "execution",
+		id,
+		node: event.node,
+		metadata: event.metadata,
+		state: "running",
+	};
+	const existingIndex = completed.findIndex((part) => part.id === id);
+	if (existingIndex === -1) return [...completed, next];
+	const copy = [...completed];
+	copy[existingIndex] = next;
+	return copy;
+};
+
+const completeExecutionParts = (
+	parts: AssistantExecutionPart[],
+): AssistantExecutionPart[] =>
+	parts.map((part) =>
+		part.state === "running" ? { ...part, state: "complete" as const } : part,
+	);
+
 
 export class ChatHandler extends BaseProcessHandler<ChatJob> {
 	constructor() {
@@ -356,6 +368,7 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 		conversation,
 		content,
 		complexContent,
+		parts,
 		metadata,
 	}: AssistantMessagePersistence) => serviceManager.databaseService.use(async ({ db, schema }) => {
 			const [existing] = await db
@@ -373,6 +386,7 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 				.set({
 					content,
 					complexContent,
+					parts,
 					metadata: sanitizeForJson({
 						...(typeof existing.metadata === "object" &&
 						existing.metadata !== null
@@ -393,7 +407,7 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 		startTime,
 		usage,
 		actions,
-		toolCalls,
+		executions,
 		error,
 	}: AssistantMessageFinalization): AssistantMessageMetadata {
 		const timeToAnswer = (Date.now() - startTime) / 1000;
@@ -408,7 +422,7 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 			tokensPerSecond: timeToAnswer > 0 ? outputTokens / timeToAnswer : 0,
 			estimatedTokens: totalTokens,
 			...(actions.length > 0 ? { actions } : {}),
-			...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+			...(executions.length > 0 ? { executions } : {}),
 			...(conversation?.agentFlowName
 				? { agentFlowName: conversation.agentFlowName }
 				: {}),
@@ -451,6 +465,8 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 
 	private static createHandleChunk(deps: FlowStreamDeps) {
 		return async (chunk: ChatCompletionChunk) => {
+			deps.onChunk?.(chunk);
+
 			if (chunk.usage) {
 				deps.onUsage?.(chunk.usage);
 			}
@@ -469,7 +485,8 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 				deps.onToolCalls?.(delta.tool_calls);
 			}
 
-			const content = delta?.content ?? "";
+			const isToolResultChunk = delta?.role === "tool" || !!delta?.tool_call_id;
+			const content = isToolResultChunk ? "" : (delta?.content ?? "");
 			if (content) {
 				deps.streamBuffer.add(content);
 			}
@@ -546,6 +563,7 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 		dependencies,
 		streamBuffer,
 		actions,
+		messagePartsAccumulator,
 		toolCallAccumulator,
 		addUsage,
 		getProgress,
@@ -558,6 +576,7 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 				dependencies,
 				streamBuffer,
 				getProgress,
+				onChunk: (chunk) => messagePartsAccumulator.addChunk(chunk),
 				onUsage: addUsage,
 				onToolCalls: (toolCalls) =>
 					accumulateChunkToolCalls(toolCallAccumulator, toolCalls),
@@ -570,18 +589,51 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 		};
 	}
 
+	private static async runFlowStream({
+		stream,
+		executeStage,
+		handleExecutionStart,
+		...runtimeDeps
+	}: FlowStreamRunDeps): Promise<Record<string, unknown> | null> {
+		const { handleChunk, handleActions } =
+			ChatHandler.createFlowRuntime(runtimeDeps);
+
+		let finalState: Record<string, unknown> | null = null;
+		for await (const partial of stream) {
+			const { mode, payload } = normalizeLangGraphStreamChunk(partial);
+
+			if (mode === "custom") {
+				await ChatHandler.handleFlowCustomPayload({
+					payload,
+					handleChunk,
+					handleActions,
+					handleExecutionStart,
+					dependencies: runtimeDeps.dependencies,
+					jobId: runtimeDeps.jobId,
+					executeStage,
+				});
+				continue;
+			}
+
+			if (mode === "values") {
+				finalState = payload as Record<string, unknown>;
+			}
+		}
+
+		return finalState;
+	}
+
 	private static async handleFlowCustomPayload({
 		payload,
 		handleChunk,
 		handleActions,
-		actions,
-		contentParts,
+		handleExecutionStart,
 		dependencies,
 		jobId,
 		executeStage,
-	}: FlowCustomPayloadDeps): Promise<ComplexContent | null> {
+	}: FlowCustomPayloadDeps): Promise<void> {
 		if (!isCustomChunkPayload(payload)) {
-			return null;
+			return;
 		}
 
 		switch (payload.type) {
@@ -589,19 +641,19 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 				if ("chunk" in payload) {
 					await handleChunk(payload.chunk as ChatCompletionChunk);
 				}
-				return contentParts;
+				return;
 			case "actions":
 				if ("actions" in payload) {
 					handleActions(payload.actions as FlowAction[]);
-					return upsertToolParts(contentParts, normalizeActions(actions));
 				}
-				return contentParts;
+				return;
 			case "execute-start":
 				if ("node" in payload) {
 					const event = {
 						node: payload.node,
 						metadata: payload.metadata,
 					};
+					handleExecutionStart(event);
 					await dependencies.updateJobProgress(jobId, {
 						stage: executeStage,
 						progress: 12,
@@ -611,11 +663,10 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 							metadata: event.metadata,
 						} as ChatResult,
 					});
-					return upsertExecutionPart(contentParts, event);
 				}
-				return contentParts;
+				return;
 			default:
-				return contentParts;
+				return;
 		}
 	}
 
@@ -669,9 +720,17 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 		);
 
 		let currentContent = "";
-		let contentParts: ComplexContent = [];
+		const messagePartsAccumulator = new MessagePartsAccumulator();
+		let finalMessageState: Record<string, unknown> | null = null;
 		const actions: FlowAction[] = [];
-		const toolCallAccumulator: ToolCallAccumulator = new Map();
+		let executions: AssistantExecutionPart[] = [];
+		const handleExecutionStart = (event: {
+			node: string;
+			metadata?: Record<string, unknown>;
+		}) => {
+			executions = addExecutionPart(executions, event);
+		};
+		const toolCallAccumulator = createToolCallAccumulator();
 		const accumulatedUsage: TokenUsage = {
 			prompt_tokens: 0,
 			completion_tokens: 0,
@@ -711,10 +770,6 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 			dependencies,
 			onContent: (bufferedContent) => {
 				currentContent += bufferedContent;
-				contentParts = appendTextPart(
-					completeRunningExecutionParts(contentParts),
-					bufferedContent,
-				);
 			},
 			getProgress: () => Math.min(80, 20 + currentContent.length / 10),
 		});
@@ -764,51 +819,27 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 					},
 				);
 
-				const responseProgress = () =>
-					Math.min(80, 20 + currentContent.length / 10);
-				const { handleChunk, handleActions } = ChatHandler.createFlowRuntime({
+				const finalState = await ChatHandler.runFlowStream({
+					stream,
+					executeStage: "Executing agent action...",
+					handleExecutionStart,
 					jobId,
 					model,
 					config,
 					dependencies,
 					streamBuffer,
 					actions,
+					messagePartsAccumulator,
 					toolCallAccumulator,
 					addUsage,
-					getProgress: responseProgress,
+					getProgress: () => Math.min(80, 20 + currentContent.length / 10),
 				});
-
-				let finalState: Record<string, unknown> | null = null;
-				for await (const partial of stream) {
-					const { mode, payload } = normalizeLangGraphStreamChunk(partial);
-
-					if (mode === "custom") {
-						const nextContentParts = await ChatHandler.handleFlowCustomPayload({
-							payload,
-							handleChunk,
-							handleActions,
-							actions,
-							contentParts,
-							dependencies,
-							jobId,
-							executeStage: "Executing agent action...",
-						});
-						if (nextContentParts) {
-							contentParts = nextContentParts;
-						}
-						continue;
-					}
-
-					if (mode === "values") {
-						finalState = payload as Record<string, unknown>;
-					}
-				}
+				finalMessageState = finalState;
 
 				streamBuffer.flush();
 
 				if (typeof finalState?.response === "string") {
 					currentContent = finalState.response;
-					contentParts = replaceTextParts(contentParts, currentContent);
 					await dependencies.updateJobProgress(jobId, {
 						stage: "Agent complete",
 						progress: 95,
@@ -905,8 +936,6 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 					resolvedConfig,
 				);
 
-				let finalState: FoundationState | null = null;
-
 				const stream = await graph.stream(
 					getInitialState({ messages, topicId, contextQueries }),
 					{
@@ -914,45 +943,22 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 					},
 				);
 
-				const responseProgress = () =>
-					Math.min(80, 20 + currentContent.length / 10);
-				const { handleChunk, handleActions } = ChatHandler.createFlowRuntime({
+				const finalState = (await ChatHandler.runFlowStream({
+					stream,
+					executeStage: "Executing...",
+					handleExecutionStart,
 					jobId,
 					model,
 					config,
 					dependencies,
 					streamBuffer,
 					actions,
+					messagePartsAccumulator,
 					toolCallAccumulator,
 					addUsage,
-					getProgress: responseProgress,
-				});
-
-				for await (const partial of stream) {
-					const { mode, payload } = normalizeLangGraphStreamChunk(partial);
-
-					if (mode === "custom") {
-						const nextContentParts = await ChatHandler.handleFlowCustomPayload({
-							payload,
-							handleChunk,
-							handleActions,
-							actions,
-							contentParts,
-							dependencies,
-							jobId,
-							executeStage: "Executing...",
-						});
-						if (nextContentParts) {
-							contentParts = nextContentParts;
-						}
-						continue;
-					}
-
-					// Capture the final state for citation content
-					if (mode === "values") {
-						finalState = payload as FoundationState;
-					}
-				}
+					getProgress: () => Math.min(80, 20 + currentContent.length / 10),
+				})) as FoundationState | null;
+				finalMessageState = finalState as unknown as Record<string, unknown> | null;
 
 				// Flush any remaining buffered content from streaming
 				streamBuffer.flush();
@@ -963,7 +969,6 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 					// If found and different from current content, update
 					if (response && response !== currentContent) {
 						currentContent = response;
-						contentParts = replaceTextParts(contentParts, currentContent);
 
 						// Send a final update to replace the streamed content with cited version
 						await dependencies.updateJobProgress(jobId, {
@@ -1006,6 +1011,7 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 						dependencies,
 						streamBuffer,
 						getProgress: () => Math.min(80, 20 + currentContent.length / 10),
+						onChunk: (chunk) => messagePartsAccumulator.addChunk(chunk),
 						onUsage: addUsage,
 						onToolCalls: (toolCalls) =>
 							accumulateChunkToolCalls(toolCallAccumulator, toolCalls),
@@ -1018,20 +1024,13 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 			}
 
 			const finalActions = normalizeActions(actions);
-			const finalToolCalls = getAccumulatedToolCalls(toolCallAccumulator);
+			const finalParts = resolveMessageParts({
+				finalState: finalMessageState,
+				accumulatedParts: messagePartsAccumulator.toParts(),
+			});
+			const finalExecutions = completeExecutionParts(executions);
 			const finalUsage =
 				accumulatedUsage.total_tokens > 0 ? accumulatedUsage : undefined;
-			if (
-				currentContent &&
-				!contentParts.some((part) => part.type === "text")
-			) {
-				contentParts = appendTextPart(contentParts, currentContent);
-			}
-			const finalContentParts = stripTransientExecutionParts(contentParts);
-			const hasToolParts = finalContentParts.some(
-				(part) => part.type === "tool",
-			);
-			const resultContent = finalContentParts.length > 0 ? "" : currentContent;
 			const finalMetadata = ChatHandler.buildAssistantMessageMetadata({
 				conversation,
 				content: currentContent,
@@ -1039,21 +1038,23 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 				provider,
 				startTime,
 				usage: finalUsage,
-				actions: hasToolParts ? [] : finalActions,
-				toolCalls: hasToolParts ? [] : finalToolCalls,
+				actions: finalActions,
+				executions: finalExecutions,
 			});
 			const result = {
 				type: "final",
-				content: resultContent,
+				content: currentContent,
+				parts: finalParts,
 				metadata: {
 					...finalMetadata,
-					contentParts: finalContentParts,
+					executions: finalExecutions,
 				},
 			} satisfies ChatResult;
 
 			await finalizeConversation({
-				content: resultContent,
-				complexContent: finalContentParts,
+				content: finalParts.length > 0 ? "" : currentContent,
+				complexContent: null,
+				parts: finalParts.length > 0 ? finalParts : null,
 				metadata: finalMetadata,
 			});
 
@@ -1061,14 +1062,14 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 		} catch (error) {
 			const errorMessage = getErrorMessage(error);
 			const errorMetadata = createJobErrorMetadata(error);
-			const isAbort = errorMessage === "Operation aborted";
-			const errorContentParts = stripTransientExecutionParts(contentParts);
-			const hasErrorToolParts = errorContentParts.some(
-				(part) => part.type === "tool",
-			);
+			const isAbort = isAbortError(error);
 			const errorUsage =
 				accumulatedUsage.total_tokens > 0 ? accumulatedUsage : undefined;
 			try {
+				const errorParts = resolveMessageParts({
+					finalState: finalMessageState,
+					accumulatedParts: messagePartsAccumulator.toParts(),
+				});
 				const persistenceMetadata = ChatHandler.buildAssistantMessageMetadata({
 					conversation,
 					content: currentContent,
@@ -1076,15 +1077,14 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 					provider,
 					startTime,
 					usage: errorUsage,
-					actions: hasErrorToolParts ? [] : normalizeActions(actions),
-					toolCalls: hasErrorToolParts
-						? []
-						: getAccumulatedToolCalls(toolCallAccumulator),
+					actions: normalizeActions(actions),
+					executions: completeExecutionParts(executions),
 					error: isAbort ? undefined : errorMetadata,
 				});
 				await finalizeConversation({
-					content: errorContentParts.length > 0 ? "" : currentContent,
-					complexContent: errorContentParts,
+					content: errorParts.length > 0 ? "" : currentContent,
+					complexContent: null,
+					parts: errorParts.length > 0 ? errorParts : null,
 					metadata: persistenceMetadata,
 				});
 			} catch (persistError) {

--- a/src/services/background-jobs/handlers/process-chat.ts
+++ b/src/services/background-jobs/handlers/process-chat.ts
@@ -1022,28 +1022,23 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 					progress: 20,
 				});
 
-				try {
-					// Use the exact same pattern from use-chat.ts lines 294-304
-					if (request.stream) {
-						// For streaming, the result should be an AsyncIterableIterator
-						const stream = serviceManager.llmService.chatCompletions(
-							request,
-						) as AsyncIterableIterator<ChatCompletionChunk>;
-						const handleChunk = ChatHandler.createHandleChunk({
-							jobId,
-							model,
-							config,
-							dependencies,
-							streamBuffer,
-							getProgress: () => Math.min(80, 20 + currentContent.length / 10),
-							onUsage: addUsage,
-							onToolCalls: (toolCalls) =>
-								accumulateChunkToolCalls(toolCallAccumulator, toolCalls),
-						});
-						await ChatHandler.streamChatCompletions(stream, handleChunk);
-					}
-				} catch (streamError) {
-					throw streamError;
+				if (request.stream) {
+					// For streaming, the result should be an AsyncIterableIterator
+					const stream = serviceManager.llmService.chatCompletions(
+						request,
+					) as AsyncIterableIterator<ChatCompletionChunk>;
+					const handleChunk = ChatHandler.createHandleChunk({
+						jobId,
+						model,
+						config,
+						dependencies,
+						streamBuffer,
+						getProgress: () => Math.min(80, 20 + currentContent.length / 10),
+						onUsage: addUsage,
+						onToolCalls: (toolCalls) =>
+							accumulateChunkToolCalls(toolCallAccumulator, toolCalls),
+					});
+					await ChatHandler.streamChatCompletions(stream, handleChunk);
 				}
 
 				// Flush any remaining buffered content
@@ -1102,23 +1097,30 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 			const errorToolCalls = getAccumulatedToolCalls(toolCallAccumulator);
 			const errorUsage =
 				accumulatedUsage.total_tokens > 0 ? accumulatedUsage : undefined;
-			const persistenceMetadata =
-				await ChatHandler.buildAssistantMessageMetadata({
-					conversation,
-					content: currentContent,
-					model,
-					startTime,
-					usage: errorUsage,
-					actions: hasErrorToolParts ? [] : errorActions,
-					toolCalls: hasErrorToolParts ? [] : errorToolCalls,
-					error: isAbort ? undefined : errorMetadata,
+			try {
+				const persistenceMetadata =
+					await ChatHandler.buildAssistantMessageMetadata({
+						conversation,
+						content: currentContent,
+						model,
+						startTime,
+						usage: errorUsage,
+						actions: hasErrorToolParts ? [] : errorActions,
+						toolCalls: hasErrorToolParts ? [] : errorToolCalls,
+						error: isAbort ? undefined : errorMetadata,
+					});
+				await finalizeConversation({
+					content: errorContentParts.length > 0 ? "" : currentContent,
+					complexContent: errorContentParts,
+					metadata: persistenceMetadata,
 				});
-
-			await finalizeConversation({
-				content: errorContentParts.length > 0 ? "" : currentContent,
-				complexContent: errorContentParts,
-				metadata: persistenceMetadata,
-			});
+			} catch (persistError) {
+				await dependencies.logger.warn(
+					`Failed to persist error state for job ${jobId}`,
+					`${persistError}`,
+					"offscreen",
+				);
+			}
 
 			await dependencies.logger.error(
 				`❌ Chat job ${jobId} failed`,

--- a/src/services/background-jobs/handlers/process-chat.ts
+++ b/src/services/background-jobs/handlers/process-chat.ts
@@ -358,7 +358,6 @@ const completeExecutionParts = (
 		part.state === "running" ? { ...part, state: "complete" as const } : part,
 	);
 
-
 export class ChatHandler extends BaseProcessHandler<ChatJob> {
 	constructor() {
 		super();
@@ -370,7 +369,8 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 		complexContent,
 		parts,
 		metadata,
-	}: AssistantMessagePersistence) => serviceManager.databaseService.use(async ({ db, schema }) => {
+	}: AssistantMessagePersistence) =>
+		serviceManager.databaseService.use(async ({ db, schema }) => {
 			const [existing] = await db
 				.select()
 				.from(schema.messages)
@@ -958,7 +958,10 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 					addUsage,
 					getProgress: () => Math.min(80, 20 + currentContent.length / 10),
 				})) as FoundationState | null;
-				finalMessageState = finalState as unknown as Record<string, unknown> | null;
+				finalMessageState = finalState as unknown as Record<
+					string,
+					unknown
+				> | null;
 
 				// Flush any remaining buffered content from streaming
 				streamBuffer.flush();

--- a/src/services/background-jobs/handlers/process-chat.ts
+++ b/src/services/background-jobs/handlers/process-chat.ts
@@ -42,6 +42,7 @@ import {
 	getErrorMessage,
 	type JobErrorMetadata,
 } from "./error-metadata";
+import { sanitizeForJson } from "@/utils/sanitize-json";
 
 export interface ChatStreamConfig {
 	/** Minimum number of words to buffer before streaming (default: 5) */
@@ -305,6 +306,7 @@ type AssistantMessageFinalization = {
 	conversation?: ConversationContext;
 	content: string;
 	model: string;
+	provider: string;
 	startTime: number;
 	usage?: TokenUsage;
 	actions: ChatResultFinalAction[];
@@ -344,48 +346,18 @@ const normalizeActions = (actions: FlowAction[]): ChatResultFinalAction[] =>
 		metadata: action.metadata,
 	}));
 
-function sanitizeForJson(value: unknown, seen = new WeakSet()): unknown {
-	if (value === undefined || value === null) return null;
-
-	const type = typeof value;
-	if (type === "string" || type === "number" || type === "boolean") {
-		return value;
-	}
-	if (type === "bigint") return value.toString();
-	if (type === "function" || type === "symbol") return null;
-	if (value instanceof Date) return value.toISOString();
-
-	if (Array.isArray(value)) {
-		return value.map((item) => sanitizeForJson(item, seen));
-	}
-
-	if (type === "object") {
-		if (seen.has(value as object)) return null;
-		seen.add(value as object);
-		const result: Record<string, unknown> = {};
-		for (const [key, item] of Object.entries(
-			value as Record<string, unknown>,
-		)) {
-			result[key] = sanitizeForJson(item, seen);
-		}
-		return result;
-	}
-
-	return null;
-}
 
 export class ChatHandler extends BaseProcessHandler<ChatJob> {
 	constructor() {
 		super();
 	}
 
-	private static async persistAssistantMessage({
+	private static persistAssistantMessage = ({
 		conversation,
 		content,
 		complexContent,
 		metadata,
-	}: AssistantMessagePersistence): Promise<void> {
-		await serviceManager.databaseService.use(async ({ db, schema }) => {
+	}: AssistantMessagePersistence) => serviceManager.databaseService.use(async ({ db, schema }) => {
 			const [existing] = await db
 				.select()
 				.from(schema.messages)
@@ -412,25 +384,22 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 				})
 				.where(eq(schema.messages.id, conversation.inProgressMessage.id));
 		});
-	}
 
-	private static async buildAssistantMessageMetadata({
+	private static buildAssistantMessageMetadata({
 		conversation,
 		content,
 		model,
+		provider,
 		startTime,
 		usage,
 		actions,
 		toolCalls,
 		error,
-	}: AssistantMessageFinalization): Promise<AssistantMessageMetadata> {
+	}: AssistantMessageFinalization): AssistantMessageMetadata {
 		const timeToAnswer = (Date.now() - startTime) / 1000;
 		const outputTokens =
 			usage?.completion_tokens ?? Math.round(content.length / 4);
 		const totalTokens = usage?.total_tokens ?? Math.round(content.length / 4);
-		const provider =
-			(await serviceManager.llmService.getCurrentModel())?.provider ??
-			"unknown";
 
 		return {
 			model,
@@ -677,6 +646,9 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 			conversation,
 		} = job.payload;
 		const startTime = Date.now();
+		const provider =
+			(await serviceManager.llmService.getCurrentModel())?.provider ??
+			"unknown";
 
 		// Apply default stream config
 		const config: Required<ChatStreamConfig> = {
@@ -1060,10 +1032,11 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 				(part) => part.type === "tool",
 			);
 			const resultContent = finalContentParts.length > 0 ? "" : currentContent;
-			const finalMetadata = await ChatHandler.buildAssistantMessageMetadata({
+			const finalMetadata = ChatHandler.buildAssistantMessageMetadata({
 				conversation,
 				content: currentContent,
 				model,
+				provider,
 				startTime,
 				usage: finalUsage,
 				actions: hasToolParts ? [] : finalActions,
@@ -1093,22 +1066,22 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 			const hasErrorToolParts = errorContentParts.some(
 				(part) => part.type === "tool",
 			);
-			const errorActions = normalizeActions(actions);
-			const errorToolCalls = getAccumulatedToolCalls(toolCallAccumulator);
 			const errorUsage =
 				accumulatedUsage.total_tokens > 0 ? accumulatedUsage : undefined;
 			try {
-				const persistenceMetadata =
-					await ChatHandler.buildAssistantMessageMetadata({
-						conversation,
-						content: currentContent,
-						model,
-						startTime,
-						usage: errorUsage,
-						actions: hasErrorToolParts ? [] : errorActions,
-						toolCalls: hasErrorToolParts ? [] : errorToolCalls,
-						error: isAbort ? undefined : errorMetadata,
-					});
+				const persistenceMetadata = ChatHandler.buildAssistantMessageMetadata({
+					conversation,
+					content: currentContent,
+					model,
+					provider,
+					startTime,
+					usage: errorUsage,
+					actions: hasErrorToolParts ? [] : normalizeActions(actions),
+					toolCalls: hasErrorToolParts
+						? []
+						: getAccumulatedToolCalls(toolCallAccumulator),
+					error: isAbort ? undefined : errorMetadata,
+				});
 				await finalizeConversation({
 					content: errorContentParts.length > 0 ? "" : currentContent,
 					complexContent: errorContentParts,

--- a/src/services/background-jobs/handlers/process-chat.ts
+++ b/src/services/background-jobs/handlers/process-chat.ts
@@ -18,24 +18,42 @@ import {
 import type { ComplexContent } from "@/types/chat";
 import { handlerRegistry } from "./handler-registry";
 import type { FoundationState } from "@/services/flows/graph/foundation/state";
+import {
+	appendTextPart,
+	completeRunningExecutionParts,
+	replaceTextParts,
+	stripTransientExecutionParts,
+	upsertExecutionPart,
+	upsertToolParts,
+} from "@/services/chat/content-parts";
 import { chatFlowRegistry } from "@/services/flows/chat-flow-registry";
 import type { UnifiedFlowConfig } from "@/services/flows/interfaces/flow-config";
 import { buildDefaultFlowConfig } from "@/services/flows/build-flow-config";
 import { mergeWithDefaultConfig } from "@/services/flows/build-flow-config";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { documentFileSystemService } from "@/services/filesystem/document-filesystem";
 import {
 	getValidRecallTypes,
 	isRecallTypeValidForGrow,
 	type RecallType,
 } from "@/services/database/entities/topic-types";
-import { createJobErrorMetadata, getErrorMessage } from "./error-metadata";
+import {
+	createJobErrorMetadata,
+	getErrorMessage,
+	type JobErrorMetadata,
+} from "./error-metadata";
 
 export interface ChatStreamConfig {
 	/** Minimum number of words to buffer before streaming (default: 5) */
 	minWordsToStream?: number;
 	/** Whether to stream tool calls immediately (default: true) */
 	streamToolCallsImmediately?: boolean;
+}
+
+export interface ConversationContext {
+	id: string;
+	inProgressMessage: { id: string };
+	agentFlowName?: string;
 }
 
 export interface ChatPayload {
@@ -49,6 +67,7 @@ export interface ChatPayload {
 	tools?: ChatCompletionTool[];
 	tool_choice?: ChatCompletionToolChoiceOption;
 	parallel_tool_calls?: boolean;
+	conversation?: ConversationContext;
 }
 
 export type ChatResult =
@@ -78,6 +97,13 @@ export type ChatResult =
 					completion_tokens: number;
 					total_tokens: number;
 				};
+				model?: string;
+				provider?: string;
+				timeToAnswer?: number;
+				tokensPerSecond?: number;
+				estimatedTokens?: number;
+				agentFlowName?: string;
+				error?: JobErrorMetadata;
 			};
 	  }
 	| {
@@ -250,9 +276,176 @@ type StreamBufferDeps = {
 	getProgress: () => number;
 };
 
+type FlowCustomPayloadDeps = {
+	payload: unknown;
+	handleChunk: (chunk: ChatCompletionChunk) => Promise<void>;
+	handleActions: (actions: FlowAction[]) => void;
+	actions: FlowAction[];
+	contentParts: ComplexContent;
+	dependencies: ProcessDependencies;
+	jobId: string;
+	executeStage: string;
+};
+
+type FlowServices = Parameters<typeof chatFlowRegistry.create>[1];
+
+type FlowRuntimeDeps = {
+	jobId: string;
+	model: string;
+	config: Required<ChatStreamConfig>;
+	dependencies: ProcessDependencies;
+	streamBuffer: StreamBuffer;
+	actions: FlowAction[];
+	toolCallAccumulator: ToolCallAccumulator;
+	addUsage: (usage: TokenUsage) => void;
+	getProgress: () => number;
+};
+
+type AssistantMessageFinalization = {
+	conversation?: ConversationContext;
+	content: string;
+	model: string;
+	startTime: number;
+	usage?: TokenUsage;
+	actions: ChatResultFinalAction[];
+	toolCalls: ChatCompletionMessageToolCall[];
+	error?: JobErrorMetadata;
+};
+
+type AssistantMessagePersistence = {
+	conversation: ConversationContext;
+	content: string;
+	complexContent: ComplexContent | null;
+	metadata: AssistantMessageMetadata;
+};
+
+type AssistantMessageMetadata = {
+	model: string;
+	provider: string;
+	timeToAnswer: number;
+	tokensPerSecond: number;
+	estimatedTokens: number;
+	actions?: ChatResultFinalAction[];
+	tool_calls?: ChatCompletionMessageToolCall[];
+	usage?: TokenUsage;
+	agentFlowName?: string;
+	error?: JobErrorMetadata;
+};
+
+type ChatResultFinalAction = NonNullable<
+	NonNullable<Extract<ChatResult, { type: "final" }>["metadata"]>["actions"]
+>[number];
+
+const normalizeActions = (actions: FlowAction[]): ChatResultFinalAction[] =>
+	actions.map((action) => ({
+		id: action.id,
+		name: action.name,
+		description: action.description ?? "",
+		metadata: action.metadata,
+	}));
+
+function sanitizeForJson(value: unknown, seen = new WeakSet()): unknown {
+	if (value === undefined || value === null) return null;
+
+	const type = typeof value;
+	if (type === "string" || type === "number" || type === "boolean") {
+		return value;
+	}
+	if (type === "bigint") return value.toString();
+	if (type === "function" || type === "symbol") return null;
+	if (value instanceof Date) return value.toISOString();
+
+	if (Array.isArray(value)) {
+		return value.map((item) => sanitizeForJson(item, seen));
+	}
+
+	if (type === "object") {
+		if (seen.has(value as object)) return null;
+		seen.add(value as object);
+		const result: Record<string, unknown> = {};
+		for (const [key, item] of Object.entries(
+			value as Record<string, unknown>,
+		)) {
+			result[key] = sanitizeForJson(item, seen);
+		}
+		return result;
+	}
+
+	return null;
+}
+
 export class ChatHandler extends BaseProcessHandler<ChatJob> {
 	constructor() {
 		super();
+	}
+
+	private static async persistAssistantMessage({
+		conversation,
+		content,
+		complexContent,
+		metadata,
+	}: AssistantMessagePersistence): Promise<void> {
+		await serviceManager.databaseService.use(async ({ db, schema }) => {
+			const [existing] = await db
+				.select()
+				.from(schema.messages)
+				.where(eq(schema.messages.id, conversation.inProgressMessage.id))
+				.limit(1);
+
+			if (!existing) {
+				return;
+			}
+
+			await db
+				.update(schema.messages)
+				.set({
+					content,
+					complexContent,
+					metadata: sanitizeForJson({
+						...(typeof existing.metadata === "object" &&
+						existing.metadata !== null
+							? existing.metadata
+							: {}),
+						...metadata,
+					}) as Record<string, unknown>,
+					updatedAt: new Date(),
+				})
+				.where(eq(schema.messages.id, conversation.inProgressMessage.id));
+		});
+	}
+
+	private static async buildAssistantMessageMetadata({
+		conversation,
+		content,
+		model,
+		startTime,
+		usage,
+		actions,
+		toolCalls,
+		error,
+	}: AssistantMessageFinalization): Promise<AssistantMessageMetadata> {
+		const timeToAnswer = (Date.now() - startTime) / 1000;
+		const outputTokens =
+			usage?.completion_tokens ?? Math.round(content.length / 4);
+		const totalTokens = usage?.total_tokens ?? Math.round(content.length / 4);
+		const provider =
+			(await serviceManager.llmService.getCurrentModel())?.provider ??
+			"unknown";
+
+		return {
+			model,
+			provider,
+			timeToAnswer,
+			tokensPerSecond: timeToAnswer > 0 ? outputTokens / timeToAnswer : 0,
+			estimatedTokens: totalTokens,
+			...(actions.length > 0 ? { actions } : {}),
+			...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+			...(conversation?.agentFlowName
+				? { agentFlowName: conversation.agentFlowName }
+				: {}),
+			...(usage ? { usage } : {}),
+			...(error ? { error } : {}),
+		};
 	}
 
 	private static createStreamBuffer(deps: StreamBufferDeps): StreamBuffer {
@@ -366,6 +559,97 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 		};
 	}
 
+	private static getFlowServices(): FlowServices {
+		return {
+			llm: serviceManager.llmService,
+			embedding: serviceManager.embeddingService,
+			database: serviceManager.databaseService,
+			sandboxContainer: serviceManager.getSandboxContainerService(),
+			webBrowser: serviceManager.getWebBrowserService(),
+			documentFileSystem: documentFileSystemService,
+		};
+	}
+
+	private static createFlowRuntime({
+		jobId,
+		model,
+		config,
+		dependencies,
+		streamBuffer,
+		actions,
+		toolCallAccumulator,
+		addUsage,
+		getProgress,
+	}: FlowRuntimeDeps) {
+		return {
+			handleChunk: ChatHandler.createHandleChunk({
+				jobId,
+				model,
+				config,
+				dependencies,
+				streamBuffer,
+				getProgress,
+				onUsage: addUsage,
+				onToolCalls: (toolCalls) =>
+					accumulateChunkToolCalls(toolCallAccumulator, toolCalls),
+			}),
+			handleActions: ChatHandler.createFlowHandleActions(
+				dependencies,
+				jobId,
+				actions,
+			),
+		};
+	}
+
+	private static async handleFlowCustomPayload({
+		payload,
+		handleChunk,
+		handleActions,
+		actions,
+		contentParts,
+		dependencies,
+		jobId,
+		executeStage,
+	}: FlowCustomPayloadDeps): Promise<ComplexContent | null> {
+		if (!isCustomChunkPayload(payload)) {
+			return null;
+		}
+
+		switch (payload.type) {
+			case "llm":
+				if ("chunk" in payload) {
+					await handleChunk(payload.chunk as ChatCompletionChunk);
+				}
+				return contentParts;
+			case "actions":
+				if ("actions" in payload) {
+					handleActions(payload.actions as FlowAction[]);
+					return upsertToolParts(contentParts, normalizeActions(actions));
+				}
+				return contentParts;
+			case "execute-start":
+				if ("node" in payload) {
+					const event = {
+						node: payload.node,
+						metadata: payload.metadata,
+					};
+					await dependencies.updateJobProgress(jobId, {
+						stage: executeStage,
+						progress: 12,
+						result: {
+							type: "execute-start",
+							node: event.node,
+							metadata: event.metadata,
+						} as ChatResult,
+					});
+					return upsertExecutionPart(contentParts, event);
+				}
+				return contentParts;
+			default:
+				return contentParts;
+		}
+	}
+
 	private static async streamChatCompletions(
 		stream: AsyncIterableIterator<ChatCompletionChunk>,
 		handleChunk: (chunk: ChatCompletionChunk) => Promise<void>,
@@ -390,7 +674,9 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 			tools,
 			tool_choice,
 			parallel_tool_calls,
+			conversation,
 		} = job.payload;
+		const startTime = Date.now();
 
 		// Apply default stream config
 		const config: Required<ChatStreamConfig> = {
@@ -411,6 +697,7 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 		);
 
 		let currentContent = "";
+		let contentParts: ComplexContent = [];
 		const actions: FlowAction[] = [];
 		const toolCallAccumulator: ToolCallAccumulator = new Map();
 		const accumulatedUsage: TokenUsage = {
@@ -423,6 +710,26 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 			accumulatedUsage.completion_tokens += usage.completion_tokens;
 			accumulatedUsage.total_tokens += usage.total_tokens;
 		};
+		const finalizeConversation = async (
+			input: Omit<AssistantMessagePersistence, "conversation">,
+		) => {
+			if (!conversation) {
+				return;
+			}
+
+			try {
+				await ChatHandler.persistAssistantMessage({
+					conversation,
+					...input,
+				});
+			} catch (finalizeError) {
+				await dependencies.logger.warn(
+					`Failed to finalize assistant message for conversation ${conversation.id}`,
+					`${finalizeError}`,
+					"offscreen",
+				);
+			}
+		};
 
 		// Create stream buffer for content
 		const streamBuffer = ChatHandler.createStreamBuffer({
@@ -432,6 +739,10 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 			dependencies,
 			onContent: (bufferedContent) => {
 				currentContent += bufferedContent;
+				contentParts = appendTextPart(
+					completeRunningExecutionParts(contentParts),
+					bufferedContent,
+				);
 			},
 			getProgress: () => Math.min(80, 20 + currentContent.length / 10),
 		});
@@ -469,17 +780,9 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 				const resolvedConfig = flowConfig
 					? mergeWithDefaultConfig(flowConfig, flowConfig.graphType)
 					: buildDefaultFlowConfig("agent");
-				const allServices = {
-					llm: serviceManager.llmService,
-					embedding: serviceManager.embeddingService,
-					database: serviceManager.databaseService,
-					sandboxContainer: serviceManager.getSandboxContainerService(),
-					webBrowser: serviceManager.getWebBrowserService(),
-					documentFileSystem: documentFileSystemService,
-				};
 				const { graph, getInitialState } = chatFlowRegistry.create(
 					resolvedConfig.graphType ?? "agent",
-					allServices,
+					ChatHandler.getFlowServices(),
 					resolvedConfig,
 				);
 				const stream = await graph.stream(
@@ -491,52 +794,35 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 
 				const responseProgress = () =>
 					Math.min(80, 20 + currentContent.length / 10);
-				const handleChunk = ChatHandler.createHandleChunk({
+				const { handleChunk, handleActions } = ChatHandler.createFlowRuntime({
 					jobId,
 					model,
 					config,
 					dependencies,
 					streamBuffer,
-					getProgress: responseProgress,
-					onUsage: addUsage,
-					onToolCalls: (toolCalls) =>
-						accumulateChunkToolCalls(toolCallAccumulator, toolCalls),
-				});
-				const handleActions = ChatHandler.createFlowHandleActions(
-					dependencies,
-					jobId,
 					actions,
-				);
+					toolCallAccumulator,
+					addUsage,
+					getProgress: responseProgress,
+				});
 
 				let finalState: Record<string, unknown> | null = null;
 				for await (const partial of stream) {
 					const { mode, payload } = normalizeLangGraphStreamChunk(partial);
 
-					if (mode === "custom" && isCustomChunkPayload(payload)) {
-						switch (payload.type) {
-							case "llm":
-								if ("chunk" in payload) {
-									await handleChunk(payload.chunk as ChatCompletionChunk);
-								}
-								break;
-							case "actions":
-								if ("actions" in payload) {
-									handleActions(payload.actions as FlowAction[]);
-								}
-								break;
-							case "execute-start":
-								if ("node" in payload) {
-									dependencies.updateJobProgress(jobId, {
-										stage: "Executing agent action...",
-										progress: 12,
-										result: {
-											type: "execute-start",
-											node: payload.node,
-											metadata: payload.metadata,
-										} as ChatResult,
-									});
-								}
-								break;
+					if (mode === "custom") {
+						const nextContentParts = await ChatHandler.handleFlowCustomPayload({
+							payload,
+							handleChunk,
+							handleActions,
+							actions,
+							contentParts,
+							dependencies,
+							jobId,
+							executeStage: "Executing agent action...",
+						});
+						if (nextContentParts) {
+							contentParts = nextContentParts;
 						}
 						continue;
 					}
@@ -550,6 +836,7 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 
 				if (typeof finalState?.response === "string") {
 					currentContent = finalState.response;
+					contentParts = replaceTextParts(contentParts, currentContent);
 					await dependencies.updateJobProgress(jobId, {
 						stage: "Agent complete",
 						progress: 95,
@@ -640,17 +927,9 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 
 				// Resolve the chat flow via registry — no graph-type branching here.
 				// Each graph module self-registers its adapter in chat-flow-registry.ts.
-				const allServices = {
-					llm: serviceManager.llmService,
-					embedding: serviceManager.embeddingService,
-					database: serviceManager.databaseService,
-					sandboxContainer: serviceManager.getSandboxContainerService(),
-					webBrowser: serviceManager.getWebBrowserService(),
-					documentFileSystem: documentFileSystemService,
-				};
 				const { graph, getInitialState } = chatFlowRegistry.create(
 					graphType,
-					allServices,
+					ChatHandler.getFlowServices(),
 					resolvedConfig,
 				);
 
@@ -665,51 +944,34 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 
 				const responseProgress = () =>
 					Math.min(80, 20 + currentContent.length / 10);
-				const handleChunk = ChatHandler.createHandleChunk({
+				const { handleChunk, handleActions } = ChatHandler.createFlowRuntime({
 					jobId,
 					model,
 					config,
 					dependencies,
 					streamBuffer,
-					getProgress: responseProgress,
-					onUsage: addUsage,
-					onToolCalls: (toolCalls) =>
-						accumulateChunkToolCalls(toolCallAccumulator, toolCalls),
-				});
-				const handleActions = ChatHandler.createFlowHandleActions(
-					dependencies,
-					jobId,
 					actions,
-				);
+					toolCallAccumulator,
+					addUsage,
+					getProgress: responseProgress,
+				});
 
 				for await (const partial of stream) {
 					const { mode, payload } = normalizeLangGraphStreamChunk(partial);
 
-					if (mode === "custom" && isCustomChunkPayload(payload)) {
-						switch (payload.type) {
-							case "llm":
-								if ("chunk" in payload) {
-									await handleChunk(payload.chunk as ChatCompletionChunk);
-								}
-								break;
-							case "actions":
-								if ("actions" in payload) {
-									handleActions(payload.actions as FlowAction[]);
-								}
-								break;
-							case "execute-start":
-								if ("node" in payload) {
-									dependencies.updateJobProgress(jobId, {
-										stage: "Executing...",
-										progress: 12,
-										result: {
-											type: "execute-start",
-											node: payload.node,
-											metadata: payload.metadata,
-										} as ChatResult,
-									});
-								}
-								break;
+					if (mode === "custom") {
+						const nextContentParts = await ChatHandler.handleFlowCustomPayload({
+							payload,
+							handleChunk,
+							handleActions,
+							actions,
+							contentParts,
+							dependencies,
+							jobId,
+							executeStage: "Executing...",
+						});
+						if (nextContentParts) {
+							contentParts = nextContentParts;
 						}
 						continue;
 					}
@@ -729,6 +991,7 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 					// If found and different from current content, update
 					if (response && response !== currentContent) {
 						currentContent = response;
+						contentParts = replaceTextParts(contentParts, currentContent);
 
 						// Send a final update to replace the streamed content with cited version
 						await dependencies.updateJobProgress(jobId, {
@@ -787,19 +1050,76 @@ export class ChatHandler extends BaseProcessHandler<ChatJob> {
 				streamBuffer.flush();
 			}
 
-			return {
-				type: "final",
+			const finalActions = normalizeActions(actions);
+			const finalToolCalls = getAccumulatedToolCalls(toolCallAccumulator);
+			const finalUsage =
+				accumulatedUsage.total_tokens > 0 ? accumulatedUsage : undefined;
+			if (
+				currentContent &&
+				!contentParts.some((part) => part.type === "text")
+			) {
+				contentParts = appendTextPart(contentParts, currentContent);
+			}
+			const finalContentParts = stripTransientExecutionParts(contentParts);
+			const hasToolParts = finalContentParts.some(
+				(part) => part.type === "tool",
+			);
+			const resultContent = finalContentParts.length > 0 ? "" : currentContent;
+			const finalMetadata = await ChatHandler.buildAssistantMessageMetadata({
+				conversation,
 				content: currentContent,
+				model,
+				startTime,
+				usage: finalUsage,
+				actions: hasToolParts ? [] : finalActions,
+				toolCalls: hasToolParts ? [] : finalToolCalls,
+			});
+			const result = {
+				type: "final",
+				content: resultContent,
 				metadata: {
-					actions,
-					tool_calls: getAccumulatedToolCalls(toolCallAccumulator),
-					usage:
-						accumulatedUsage.total_tokens > 0 ? accumulatedUsage : undefined,
+					...finalMetadata,
+					contentParts: finalContentParts,
 				},
-			};
+			} satisfies ChatResult;
+
+			await finalizeConversation({
+				content: resultContent,
+				complexContent: finalContentParts,
+				metadata: finalMetadata,
+			});
+
+			return result;
 		} catch (error) {
 			const errorMessage = getErrorMessage(error);
 			const errorMetadata = createJobErrorMetadata(error);
+			const isAbort = errorMessage === "Operation aborted";
+			const errorContentParts = stripTransientExecutionParts(contentParts);
+			const hasErrorToolParts = errorContentParts.some(
+				(part) => part.type === "tool",
+			);
+			const errorActions = normalizeActions(actions);
+			const errorToolCalls = getAccumulatedToolCalls(toolCallAccumulator);
+			const errorUsage =
+				accumulatedUsage.total_tokens > 0 ? accumulatedUsage : undefined;
+			const persistenceMetadata =
+				await ChatHandler.buildAssistantMessageMetadata({
+					conversation,
+					content: currentContent,
+					model,
+					startTime,
+					usage: errorUsage,
+					actions: hasErrorToolParts ? [] : errorActions,
+					toolCalls: hasErrorToolParts ? [] : errorToolCalls,
+					error: isAbort ? undefined : errorMetadata,
+				});
+
+			await finalizeConversation({
+				content: errorContentParts.length > 0 ? "" : currentContent,
+				complexContent: errorContentParts,
+				metadata: persistenceMetadata,
+			});
+
 			await dependencies.logger.error(
 				`❌ Chat job ${jobId} failed`,
 				error,

--- a/src/services/background-jobs/handlers/process-embedded-chat-history.ts
+++ b/src/services/background-jobs/handlers/process-embedded-chat-history.ts
@@ -1,6 +1,7 @@
 import { and, asc, desc, eq, gt, ne } from "drizzle-orm";
 import { serviceManager } from "@/services";
 import { v4 } from "@/utils/uuid";
+import { sanitizeForJson } from "@/utils/sanitize-json";
 import { backgroundProcessFactory } from "./process-factory";
 import type {
 	BaseJob,
@@ -41,36 +42,6 @@ export interface EmbeddedChatHistoryResult extends Record<string, unknown> {
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null;
-
-const sanitizeForJson = (value: unknown, seen = new WeakSet()): unknown => {
-	if (value === undefined || value === null) return null;
-
-	const type = typeof value;
-	if (type === "string" || type === "number" || type === "boolean") {
-		return value;
-	}
-	if (type === "bigint") return value.toString();
-	if (type === "function" || type === "symbol") return null;
-	if (value instanceof Date) return value.toISOString();
-
-	if (Array.isArray(value)) {
-		return value.map((item) => sanitizeForJson(item, seen));
-	}
-
-	if (type === "object") {
-		if (seen.has(value as object)) return null;
-		seen.add(value as object);
-		const result: Record<string, unknown> = {};
-		for (const [key, item] of Object.entries(
-			value as Record<string, unknown>,
-		)) {
-			result[key] = sanitizeForJson(item, seen);
-		}
-		return result;
-	}
-
-	return null;
-};
 
 const ensureMainConversation = async (): Promise<Conversation> => {
 	return serviceManager.databaseService.use(async ({ db, schema }) => {

--- a/src/services/chat/content-parts.ts
+++ b/src/services/chat/content-parts.ts
@@ -69,6 +69,17 @@ export const appendTextPart = (
 	return [...next, { type: "text", text }];
 };
 
+export const replaceTextParts = (
+	parts: ComplexContent,
+	text: string,
+): ComplexContent => {
+	const nonTextParts = completeRunningExecutionParts(parts).filter(
+		(part) => part.type !== "text",
+	);
+	if (!text) return nonTextParts;
+	return [...nonTextParts, { type: "text", text }];
+};
+
 export const upsertExecutionPart = (
 	parts: ComplexContent,
 	event: { node: string; metadata?: Record<string, unknown> },

--- a/src/services/chat/content-parts.ts
+++ b/src/services/chat/content-parts.ts
@@ -1,56 +1,7 @@
-import type {
-	ComplexContent,
-	ComplexContentPart,
-	ComplexContentPartExecution,
-	ComplexContentPartText,
-	ComplexContentPartTool,
-} from "@/types/chat";
-
-export type ContentPartAction = {
-	id: string;
-	name: string;
-	description: string;
-	metadata: Record<string, unknown>;
-};
+import type { ComplexContent } from "@/types/chat";
 
 export const cloneContentParts = (parts: ComplexContent): ComplexContent =>
-	parts.map((part) => ({
-		...part,
-		...("metadata" in part && part.metadata
-			? { metadata: { ...part.metadata } }
-			: {}),
-	}));
-
-export const completeRunningExecutionParts = (
-	parts: ComplexContent,
-): ComplexContent =>
-	parts.map((part) =>
-		part.type === "execution" && part.state === "running"
-			? { ...part, state: "complete" }
-			: part,
-	);
-
-const getToolPartKey = (part: {
-	id?: string;
-	name?: string;
-	metadata?: Record<string, unknown>;
-}): string | undefined => {
-	const toolCall = part.metadata?.tool_call;
-	if (
-		toolCall &&
-		typeof toolCall === "object" &&
-		"id" in toolCall &&
-		typeof toolCall.id === "string"
-	) {
-		return toolCall.id;
-	}
-	const toolCallId = part.metadata?.tool_call_id;
-	if (typeof toolCallId === "string" && toolCallId) return toolCallId;
-	const tool = part.metadata?.tool;
-	if (typeof tool === "string" && tool) return tool;
-	if (part.id) return part.id;
-	return part.name;
-};
+	parts.map((part) => ({ ...part }));
 
 export const appendTextPart = (
 	parts: ComplexContent,
@@ -63,89 +14,8 @@ export const appendTextPart = (
 		next[next.length - 1] = {
 			...last,
 			text: `${last.text}${text}`,
-		} satisfies ComplexContentPartText;
+		};
 		return next;
 	}
 	return [...next, { type: "text", text }];
 };
-
-export const replaceTextParts = (
-	parts: ComplexContent,
-	text: string,
-): ComplexContent => {
-	const nonTextParts = completeRunningExecutionParts(parts).filter(
-		(part) => part.type !== "text",
-	);
-	if (!text) return nonTextParts;
-	return [...nonTextParts, { type: "text", text }];
-};
-
-export const upsertExecutionPart = (
-	parts: ComplexContent,
-	event: { node: string; metadata?: Record<string, unknown> },
-): ComplexContent => {
-	const completedParts = completeRunningExecutionParts(parts);
-	const id =
-		(typeof event.metadata?.tool_call_id === "string" &&
-			event.metadata.tool_call_id) ||
-		(typeof event.metadata?.tool === "string" && event.metadata.tool) ||
-		event.node;
-	const executionPart: ComplexContentPartExecution = {
-		type: "execution",
-		id,
-		node: event.node,
-		metadata: event.metadata,
-		state: "running",
-	};
-	const executionKey = getToolPartKey(executionPart);
-	const existingIndex = completedParts.findIndex(
-		(part) =>
-			(part.type === "execution" || part.type === "tool") &&
-			getToolPartKey(part) === executionKey,
-	);
-	if (existingIndex === -1) return [...completedParts, executionPart];
-	const next = [...completedParts];
-	next[existingIndex] = executionPart;
-	return next;
-};
-
-export const upsertToolParts = (
-	parts: ComplexContent,
-	incomingActions: ContentPartAction[],
-): ComplexContent => {
-	let next = completeRunningExecutionParts(parts);
-	for (const action of incomingActions) {
-		const toolPart: ComplexContentPartTool = {
-			type: "tool",
-			id: action.id,
-			name: action.name,
-			description: action.description,
-			metadata: action.metadata,
-			state:
-				action.name.toLowerCase().includes("error") ||
-				typeof action.metadata?.error === "string"
-					? "error"
-					: "complete",
-		};
-		const toolKey = getToolPartKey(toolPart);
-		const existingIndex = next.findIndex(
-			(part) =>
-				(part.type === "execution" || part.type === "tool") &&
-				getToolPartKey(part) === toolKey,
-		);
-		if (existingIndex === -1) {
-			next = [...next, toolPart];
-		} else {
-			next[existingIndex] = toolPart;
-		}
-	}
-	return next;
-};
-
-export const stripTransientExecutionParts = (
-	parts: ComplexContent,
-): ComplexContent =>
-	parts.filter(
-		(part): part is ComplexContentPart =>
-			part.type !== "execution" || part.state !== "running",
-	);

--- a/src/services/chat/message-parts.ts
+++ b/src/services/chat/message-parts.ts
@@ -10,10 +10,7 @@ import {
 	type ToolCallAccumulator,
 } from "@/services/chat/tool-call-accumulator";
 
-type AssistantPart = Extract<
-	ChatCompletionMessageParam,
-	{ role: "assistant" }
->;
+type AssistantPart = Extract<ChatCompletionMessageParam, { role: "assistant" }>;
 type ToolPart = Extract<ChatCompletionMessageParam, { role: "tool" }>;
 
 const isAssistantOrToolMessage = (

--- a/src/services/chat/message-parts.ts
+++ b/src/services/chat/message-parts.ts
@@ -1,0 +1,148 @@
+import type {
+	ChatCompletionChunk,
+	ChatCompletionMessageParam,
+	ChatCompletionMessageToolCall,
+} from "@/types/openai";
+import type { MessageParts } from "@/types/chat";
+import {
+	accumulateChunkToolCalls,
+	createToolCallAccumulator,
+	type ToolCallAccumulator,
+} from "@/services/chat/tool-call-accumulator";
+
+type AssistantPart = Extract<
+	ChatCompletionMessageParam,
+	{ role: "assistant" }
+>;
+type ToolPart = Extract<ChatCompletionMessageParam, { role: "tool" }>;
+
+const isAssistantOrToolMessage = (
+	message: unknown,
+): message is AssistantPart | ToolPart => {
+	if (!message || typeof message !== "object") return false;
+	if (!("role" in message)) return false;
+	return message.role === "assistant" || message.role === "tool";
+};
+
+export const getOutputMessageParts = (
+	finalState: Record<string, unknown> | null | undefined,
+): MessageParts => {
+	const outputMessages = finalState?.outputMessages;
+	if (!Array.isArray(outputMessages)) return [];
+	return outputMessages.filter(isAssistantOrToolMessage);
+};
+
+export const cloneMessageParts = (
+	parts: MessageParts | null | undefined,
+): MessageParts | null =>
+	parts
+		? parts.map((part) => ({
+				...part,
+				...(part.role === "assistant" && part.tool_calls
+					? {
+							tool_calls: part.tool_calls.map((toolCall) => ({
+								...toolCall,
+								function: { ...toolCall.function },
+							})),
+						}
+					: {}),
+			}))
+		: null;
+
+export const resolveMessageParts = ({
+	finalState,
+	accumulatedParts,
+}: {
+	finalState?: Record<string, unknown> | null;
+	accumulatedParts: MessageParts;
+}): MessageParts => {
+	const outputMessageParts = getOutputMessageParts(finalState);
+	if (outputMessageParts.length > 0) return outputMessageParts;
+	return accumulatedParts;
+};
+
+export class MessagePartsAccumulator {
+	private readonly parts: MessageParts = [];
+	private readonly assistantToolCalls = new Map<number, ToolCallAccumulator>();
+	private currentAssistantIndex: number | null = null;
+
+	addChunk(chunk: ChatCompletionChunk): void {
+		for (const choice of chunk.choices ?? []) {
+			const delta = choice.delta;
+			if (!delta) continue;
+
+			if (delta.role === "tool" || delta.tool_call_id) {
+				this.appendToolContent(delta.tool_call_id, delta.content ?? "");
+				continue;
+			}
+
+			if (
+				delta.role === "assistant" ||
+				delta.content !== undefined ||
+				delta.tool_calls?.length
+			) {
+				const assistant = this.ensureAssistantPart();
+				if (delta.content) {
+					assistant.content = `${assistant.content ?? ""}${delta.content}`;
+				}
+				if (delta.tool_calls?.length) {
+					this.mergeToolCallDeltas(delta.tool_calls);
+				}
+			}
+		}
+	}
+
+	toParts(): MessageParts {
+		return cloneMessageParts(this.parts) ?? [];
+	}
+
+	private ensureAssistantPart(): AssistantPart {
+		const last = this.parts[this.parts.length - 1];
+		if (last?.role === "assistant") {
+			this.currentAssistantIndex = this.parts.length - 1;
+			return last;
+		}
+
+		const part: AssistantPart = { role: "assistant", content: "" };
+		this.parts.push(part);
+		this.currentAssistantIndex = this.parts.length - 1;
+		return part;
+	}
+
+	private appendToolContent(
+		toolCallId: string | undefined,
+		content: string | null | undefined,
+	): void {
+		if (!toolCallId) return;
+		this.currentAssistantIndex = null;
+
+		const last = this.parts[this.parts.length - 1];
+		if (last?.role === "tool" && last.tool_call_id === toolCallId) {
+			last.content = `${last.content ?? ""}${content ?? ""}`;
+			return;
+		}
+
+		this.parts.push({
+			role: "tool",
+			content: content ?? "",
+			tool_call_id: toolCallId,
+		});
+	}
+
+	private mergeToolCallDeltas(
+		toolCalls: Parameters<typeof accumulateChunkToolCalls>[1],
+	): void {
+		if (this.currentAssistantIndex === null) return;
+		const assistant = this.parts[this.currentAssistantIndex];
+		if (assistant?.role !== "assistant") return;
+
+		let calls = this.assistantToolCalls.get(this.currentAssistantIndex);
+		if (!calls) {
+			calls = createToolCallAccumulator();
+			this.assistantToolCalls.set(this.currentAssistantIndex, calls);
+		}
+
+		accumulateChunkToolCalls(calls, toolCalls);
+		assistant.tool_calls = Array.from(calls.values());
+	}
+}

--- a/src/services/chat/tool-call-accumulator.ts
+++ b/src/services/chat/tool-call-accumulator.ts
@@ -1,0 +1,42 @@
+import type {
+	ChatCompletionChunkToolCall,
+	ChatCompletionMessageToolCall,
+} from "@/types/openai";
+
+export type ToolCallAccumulator = Map<number, ChatCompletionMessageToolCall>;
+
+export const createToolCallAccumulator = (): ToolCallAccumulator => new Map();
+
+export const accumulateChunkToolCalls = (
+	accumulator: ToolCallAccumulator,
+	toolCalls: ChatCompletionChunkToolCall[] | undefined,
+): void => {
+	if (!toolCalls?.length) return;
+
+	for (const toolCall of toolCalls) {
+		const existing = accumulator.get(toolCall.index);
+		if (existing) {
+			if (toolCall.id) existing.id = toolCall.id;
+			if (toolCall.function?.name) {
+				existing.function.name = toolCall.function.name;
+			}
+			if (toolCall.function?.arguments) {
+				existing.function.arguments += toolCall.function.arguments;
+			}
+			continue;
+		}
+
+		accumulator.set(toolCall.index, {
+			id: toolCall.id || `call_${toolCall.index}_${Date.now()}`,
+			type: "function",
+			function: {
+				name: toolCall.function?.name || "",
+				arguments: toolCall.function?.arguments || "",
+			},
+		});
+	}
+};
+
+export const getAccumulatedToolCalls = (
+	accumulator: ToolCallAccumulator,
+): ChatCompletionMessageToolCall[] => Array.from(accumulator.values());

--- a/src/services/database/entities/messages.ts
+++ b/src/services/database/entities/messages.ts
@@ -24,6 +24,7 @@ export const message = pgTable(
 		role: text("role").notNull(), // 'user', 'assistant', 'system'
 		content: text("content").notNull(),
 		complexContent: jsonb("complex_content"), // For storing structured content like images, files, etc.
+		parts: jsonb("parts"), // Canonical role-based message records for this row
 		topicId: uuid("topic_id").references(() => topic.id),
 		embeddingSmall: vector("embedding_small", { dimensions: 384 }),
 		embedding: vector("embedding", { dimensions: 768 }),

--- a/src/services/database/migrations/013_add_message_parts.ts
+++ b/src/services/database/migrations/013_add_message_parts.ts
@@ -1,0 +1,15 @@
+import type { PGlite } from "@electric-sql/pglite";
+
+export const up = async (pg: PGlite) => {
+	await pg.exec(`
+		ALTER TABLE messages
+		ADD COLUMN IF NOT EXISTS parts JSONB;
+	`);
+};
+
+export const down = async (pg: PGlite) => {
+	await pg.exec(`
+		ALTER TABLE messages
+		DROP COLUMN IF EXISTS parts;
+	`);
+};

--- a/src/services/database/migrations/index.ts
+++ b/src/services/database/migrations/index.ts
@@ -155,7 +155,8 @@ export const migrations: Migration[] = [
 	{
 		id: "add_message_parts",
 		version: 13,
-		description: "Add message parts column for canonical role-based message records",
+		description:
+			"Add message parts column for canonical role-based message records",
 		up: addMessagePartsUp,
 		down: addMessagePartsDown,
 	},

--- a/src/services/database/migrations/index.ts
+++ b/src/services/database/migrations/index.ts
@@ -45,6 +45,10 @@ import {
 	up as renameKnowledgeRagToFoundationUp,
 	down as renameKnowledgeRagToFoundationDown,
 } from "./012_rename_knowledge_rag_to_foundation";
+import {
+	up as addMessagePartsUp,
+	down as addMessagePartsDown,
+} from "./013_add_message_parts";
 // import { up as futureExampleUp, down as futureExampleDown } from './001_example_future_migration';
 
 export interface Migration {
@@ -147,6 +151,13 @@ export const migrations: Migration[] = [
 		description: "Rename predefined knowledge RAG flow records to foundation",
 		up: renameKnowledgeRagToFoundationUp,
 		down: renameKnowledgeRagToFoundationDown,
+	},
+	{
+		id: "add_message_parts",
+		version: 13,
+		description: "Add message parts column for canonical role-based message records",
+		up: addMessagePartsUp,
+		down: addMessagePartsDown,
 	},
 	// Example of how to add future migrations:
 	// {

--- a/src/services/flows/graph/agent/graph.ts
+++ b/src/services/flows/graph/agent/graph.ts
@@ -19,7 +19,6 @@ import {
 } from "@/services/flows/interfaces/tool";
 import type { ChatCompletionChunk } from "@/types/openai";
 import { logError, logInfo } from "@/utils/logger";
-import { formatYAML } from "@/utils/yaml";
 import { flowRegistry, FEATURE_SLOT } from "@/services/flows/flow-registry";
 import type { BaseFlow } from "@/services/flows/flow-registry";
 import { chatFlowRegistry } from "@/services/flows/chat-flow-registry";
@@ -34,31 +33,6 @@ type AgentServices = CombinedServices<typeof DEFAULT_TOOL_NAMES, "llm">;
 type AgentGraphConfig = {
 	systemPrompt?: string;
 	tools?: GraphTool[];
-};
-
-const isObject = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null;
-
-const parseStructuredActionPayload = (
-	content: string,
-): Record<string, unknown> | null => {
-	try {
-		const parsed = JSON.parse(content);
-		return isObject(parsed) ? parsed : null;
-	} catch {
-		return null;
-	}
-};
-
-const ACTION_OUTPUT_MAX_LENGTH = 1000;
-
-/** Truncate tool output to `ACTION_OUTPUT_MAX_LENGTH` characters. */
-const truncateOutput = (content: string): string => {
-	if (content.length <= ACTION_OUTPUT_MAX_LENGTH) return content;
-	return (
-		content.slice(0, ACTION_OUTPUT_MAX_LENGTH) +
-		`\n… (truncated, ${content.length - ACTION_OUTPUT_MAX_LENGTH} more characters)`
-	);
 };
 
 /**
@@ -266,13 +240,6 @@ export class AgentGraph extends GraphBase<
 		const toolState: AgentState = { ...state, outputMessages: [] };
 		let toolStateOffset = 0;
 		const outputMessages: AgentState["outputMessages"] = [];
-		const toolResults: Array<{
-			toolName: string;
-			content: ReturnType<typeof extractToolResult>["content"];
-			contentText: string;
-			toolCall: (typeof lastMessage.tool_calls)[number];
-			toolMetadata?: Record<string, unknown>;
-		}> = [];
 
 		logInfo("[TOOL EXECUTE] Start tool calls", lastMessage.tool_calls);
 
@@ -287,12 +254,15 @@ export class AgentGraph extends GraphBase<
 
 			if (!combined) {
 				const content = `Error: Tool '${toolName}' not found`;
-				outputMessages.push({
+				const toolMessage = {
 					role: "tool" as const,
 					content,
 					tool_call_id: toolCall.id,
-				});
-				toolResults.push({ toolName, content, contentText: content, toolCall });
+				};
+				outputMessages.push(toolMessage);
+				for (const chunk of createOutputMessageChunks([toolMessage])) {
+					runConfig?.writer?.({ type: "llm", chunk });
+				}
 				continue;
 			}
 
@@ -313,18 +283,15 @@ export class AgentGraph extends GraphBase<
 					runConfig?.writer?.({ type: "llm", chunk });
 				}
 
-				outputMessages.push({
+				const toolMessage = {
 					role: "tool" as const,
 					content,
 					tool_call_id: toolCall.id,
-				});
-				toolResults.push({
-					toolName,
-					content,
-					contentText,
-					toolCall,
-					toolMetadata: combined.executor.metadata,
-				});
+				};
+				outputMessages.push(toolMessage);
+				for (const chunk of createOutputMessageChunks([toolMessage])) {
+					runConfig?.writer?.({ type: "llm", chunk });
+				}
 				logInfo(
 					"[TOOL EXECUTE] Tool result",
 					toolCall.function.name,
@@ -336,61 +303,16 @@ export class AgentGraph extends GraphBase<
 				logError(`[TOOLS] Error executing ${toolName}:`, error);
 
 				const content = `Error: ${errorMessage}`;
-				outputMessages.push({
+				const toolMessage = {
 					role: "tool" as const,
 					content,
 					tool_call_id: toolCall.id,
-				});
-				toolResults.push({
-					toolName,
-					content,
-					contentText: content,
-					toolCall,
-					toolMetadata: combined.executor.metadata,
-				});
+				};
+				outputMessages.push(toolMessage);
+				for (const chunk of createOutputMessageChunks([toolMessage])) {
+					runConfig?.writer?.({ type: "llm", chunk });
+				}
 			}
-		}
-
-		const actions = toolResults.map((result) => {
-			const structured = parseStructuredActionPayload(result.contentText);
-			const actionName =
-				typeof structured?.actionType === "string"
-					? structured.actionType
-					: result.toolName;
-			const actionDescription =
-				typeof structured?.description === "string"
-					? structured.description
-					: result.contentText;
-			const mcpMetadata = isObject(result.toolMetadata?.mcp)
-				? result.toolMetadata.mcp
-				: undefined;
-
-			let rawArgs: Record<string, unknown> = {};
-			try {
-				const parsed = JSON.parse(result.toolCall.function.arguments);
-				if (isObject(parsed)) rawArgs = parsed;
-			} catch {
-				// leave rawArgs empty
-			}
-
-			return {
-				id: crypto.randomUUID(),
-				name: actionName,
-				description: `${formatYAML(rawArgs)}\noutput:\n${truncateOutput(actionDescription)}`,
-				metadata: {
-					tool: result.toolName,
-					tool_call: result.toolCall,
-					...(result.toolMetadata
-						? { tool_metadata: result.toolMetadata }
-						: {}),
-					...(mcpMetadata ? { mcp: mcpMetadata } : {}),
-					...(structured || {}),
-				},
-			};
-		});
-
-		if (actions.length) {
-			runConfig?.writer?.({ type: "actions", actions });
 		}
 
 		// Only update working memory — messages stays intact until agentNode finishes

--- a/src/services/flows/graph/agent/graph.ts
+++ b/src/services/flows/graph/agent/graph.ts
@@ -240,6 +240,7 @@ export class AgentGraph extends GraphBase<
 		const committedMessages = [...state.outputMessages, finalMessage];
 
 		return {
+			outputMessages: [finalMessage],
 			messages: [...state.messages, ...committedMessages],
 			response: buildResponseFromOutputMessages([], committedMessages),
 			currentIteration: state.currentIteration + 1,

--- a/src/services/flows/graph/graph.base.ts
+++ b/src/services/flows/graph/graph.base.ts
@@ -131,9 +131,15 @@ export const createOutputMessageChunks = (
 	const chunks: ChatCompletionChunk[] = [];
 
 	for (const message of messages) {
-		if (message.role !== "assistant") continue;
+		if (message.role !== "assistant" && message.role !== "tool") continue;
 		const content = messageContentToText(message.content);
-		if (!content) continue;
+		if (
+			message.role === "assistant" &&
+			!content &&
+			!message.tool_calls?.length
+		) {
+			continue;
+		}
 		chunks.push({
 			id: `chunk-${Date.now()}-${crypto.randomUUID()}`,
 			object: "chat.completion.chunk",
@@ -143,8 +149,19 @@ export const createOutputMessageChunks = (
 				{
 					index: 0,
 					delta: {
-						role: "assistant" as const,
+						role: message.role,
 						content,
+						...(message.role === "assistant" && message.tool_calls?.length
+							? { tool_calls: message.tool_calls.map((toolCall, index) => ({
+									index,
+									id: toolCall.id,
+									type: toolCall.type,
+									function: { ...toolCall.function },
+								})) }
+							: {}),
+						...(message.role === "tool"
+							? { tool_call_id: message.tool_call_id }
+							: {}),
 					},
 					finish_reason: null,
 				},

--- a/src/services/flows/graph/graph.base.ts
+++ b/src/services/flows/graph/graph.base.ts
@@ -152,12 +152,14 @@ export const createOutputMessageChunks = (
 						role: message.role,
 						content,
 						...(message.role === "assistant" && message.tool_calls?.length
-							? { tool_calls: message.tool_calls.map((toolCall, index) => ({
-									index,
-									id: toolCall.id,
-									type: toolCall.type,
-									function: { ...toolCall.function },
-								})) }
+							? {
+									tool_calls: message.tool_calls.map((toolCall, index) => ({
+										index,
+										id: toolCall.id,
+										type: toolCall.type,
+										function: { ...toolCall.function },
+									})),
+								}
 							: {}),
 						...(message.role === "tool"
 							? { tool_call_id: message.tool_call_id }

--- a/src/services/flows/tools/render-memorall-artifact.ts
+++ b/src/services/flows/tools/render-memorall-artifact.ts
@@ -61,7 +61,7 @@ const buildArtifactMessageContent = ({
 	)}"`;
 	const typeAttr = ` type="${escapeAttribute(toStandardArtifactType(type))}"`;
 	const titleAttr = title ? ` title="${escapeAttribute(title)}"` : "";
-	return `<artifact${identifierAttr}${typeAttr}${titleAttr}>${content}</artifact>`;
+	return `\n\n<artifact${identifierAttr}${typeAttr}${titleAttr}>${content}</artifact>\n\n`;
 };
 
 export const createRenderMemorallArtifactTool: ToolFactory<

--- a/src/services/llm/implementations/llm-proxy.ts
+++ b/src/services/llm/implementations/llm-proxy.ts
@@ -382,6 +382,10 @@ export class LLMProxy implements BaseLLM {
 			}
 			throw new Error("Failed to serve model");
 		} catch (error) {
+			this.emitProgressEvent(
+				{ loaded: 0, total: 0, percent: 0 },
+				error instanceof Error ? error.message : "Model load failed",
+			);
 			throw new Error(`Background job failed: ${error}`);
 		}
 	}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -16,23 +16,46 @@ export type GeneratedImage = {
 
 // ==================== COMPLEX CONTENT ====================
 
-/** Text part of a complex (multipart) message */
+import type {
+	ChatCompletionContentPart,
+	ChatCompletionMessageParam,
+} from "./openai";
+
+/** Text part of an OpenAI-compatible multipart message */
 export interface ComplexContentPartText {
 	type: "text";
 	text: string;
 }
 
-/** Image part of a complex (multipart) message — stores path in document-fs, not raw bytes */
-export interface ComplexContentPartImage {
-	type: "image";
-	/** Path in document filesystem (e.g. /home/images/<uuid>.png) */
-	path: string;
-	mimeType: string;
+/** Image part of an OpenAI-compatible multipart message */
+export interface ComplexContentPartImageUrl {
+	type: "image_url";
+	image_url: {
+		url: string;
+		detail?: "auto" | "low" | "high";
+		mimeType?: string;
+	};
+}
+
+export type ComplexContentPart =
+	| ComplexContentPartText
+	| ComplexContentPartImageUrl;
+
+/** Stored in messages.complexContent (jsonb) when the message has multipart OpenAI-compatible content */
+export type ComplexContent = ChatCompletionContentPart[];
+
+/** Stored in messages.parts (jsonb) as canonical role-based records for one DB row */
+export type MessageParts = ChatCompletionMessageParam[];
+
+export interface ConversationContext {
+	id: string;
+	inProgressMessage: { id: string };
+	agentFlowName?: string;
 }
 
 export type AssistantToolPartState = "running" | "complete" | "error";
 
-/** Tool/action part of an assistant message, stored in order with text parts. */
+/** Legacy UI-only tool/action part. Do not persist in messages.complexContent. */
 export interface ComplexContentPartTool {
 	type: "tool";
 	id: string;
@@ -42,7 +65,7 @@ export interface ComplexContentPartTool {
 	state: AssistantToolPartState;
 }
 
-/** Transient execution part used while an assistant response is streaming. */
+/** Legacy UI-only execution part. Do not persist in messages.complexContent. */
 export interface ComplexContentPartExecution {
 	type: "execution";
 	id: string;
@@ -51,14 +74,7 @@ export interface ComplexContentPartExecution {
 	state: "running" | "complete";
 }
 
-export type ComplexContentPart =
-	| ComplexContentPartText
-	| ComplexContentPartImage
-	| ComplexContentPartTool
-	| ComplexContentPartExecution;
-
-/** Stored in messages.complexContent (jsonb) when the message has multipart content */
-export type ComplexContent = ComplexContentPart[];
+export type AssistantExecutionPart = ComplexContentPartExecution;
 
 /** A skill selected from the mention popup — content is injected directly into the message */
 export interface AttachedSkillRef {

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -88,6 +88,7 @@ export interface ChatCompletionContentPartImage {
 	image_url: {
 		url: string;
 		detail?: "auto" | "low" | "high";
+		mimeType?: string;
 	};
 }
 
@@ -200,9 +201,10 @@ export interface ChatCompletionResponse {
 
 /** Streaming delta */
 export interface ChatCompletionChunkDelta {
-	role?: "assistant";
+	role?: "assistant" | "tool";
 	content?: string | null;
 	tool_calls?: ChatCompletionChunkToolCall[];
+	tool_call_id?: string;
 }
 
 /** Streaming choice */

--- a/src/utils/abort.ts
+++ b/src/utils/abort.ts
@@ -1,0 +1,9 @@
+export const ABORT_ERROR_MESSAGE = "Operation aborted";
+
+export const isAbortError = (error: unknown): boolean => {
+	if (error instanceof DOMException && error.name === "AbortError") return true;
+	if (error instanceof Error) {
+		return error.name === "AbortError" || error.message === ABORT_ERROR_MESSAGE;
+	}
+	return false;
+};

--- a/src/utils/sanitize-json.ts
+++ b/src/utils/sanitize-json.ts
@@ -1,0 +1,29 @@
+export function sanitizeForJson(value: unknown, seen = new WeakSet()): unknown {
+	if (value === undefined || value === null) return null;
+
+	const type = typeof value;
+	if (type === "string" || type === "number" || type === "boolean") {
+		return value;
+	}
+	if (type === "bigint") return (value as bigint).toString();
+	if (type === "function" || type === "symbol") return null;
+	if (value instanceof Date) return value.toISOString();
+
+	if (Array.isArray(value)) {
+		return value.map((item) => sanitizeForJson(item, seen));
+	}
+
+	if (type === "object") {
+		if (seen.has(value as object)) return null;
+		seen.add(value as object);
+		const result: Record<string, unknown> = {};
+		for (const [key, item] of Object.entries(
+			value as Record<string, unknown>,
+		)) {
+			result[key] = sanitizeForJson(item, seen);
+		}
+		return result;
+	}
+
+	return null;
+}


### PR DESCRIPTION
## 🎯 Overview

Refactors the chat message finalization flow so the background job handler owns DB writes,
instead of the UI hooks doing async saves after streaming ends. Adds canonical role-based
MessageParts persistence at the DB layer and a new streaming accumulator pipeline.

## 🔄 What changed

**Persistence layer**

- messages table gains a parts JSONB column (migration 013) for canonical role-based
  ChatCompletionMessageParam[] records
- process-chat.ts — accepts a ConversationContext (conversation ID + in-progress message ID)
  and writes the final assistant message directly, including timing metrics, provider info,
  and parts
- chat-service.ts — threads ConversationContext through to the job payload; strips
  contentParts from result metadata before returning to callers
- agent-chat.ts (cron) — stores complexContent when the result includes structured
  tool/execution parts

**Streaming accumulation**

- tool-call-accumulator.ts — dedicated accumulator for streaming tool-call deltas
- message-parts.ts — MessagePartsAccumulator class that converts SSE chunks into role-based
  MessageParts; resolveMessageParts prefers graph outputMessages over accumulated parts

**UI hooks**

- use-chat.ts / use-embedded-chat-session.ts — replace async finalizeMessage store action
  with a synchronous updateMessage call; remove duplicated timing/token calculations

**Rendering**

- message-parts-adapter.ts — new adapter that converts MessageParts into AssistantContentPart[]
  for the UI, including running/completed tool state resolution
- MessageRenderer.tsx — fixes renderable-content check to include non-empty text parts,
  not just tool/execution parts
- MessageActions.tsx / AssistantWorkflow.tsx — i18n fallback for action descriptions and
  workflow labels via common namespace
- i18n-helpers.ts — translateCommonKey helper for cross-namespace translation lookups

**Types**

- ComplexContentPartImage → ComplexContentPartImageUrl (OpenAI-compatible image_url format)
- New MessageParts = ChatCompletionMessageParam[] and ConversationContext types
- Tool/execution parts in ComplexContent marked as legacy UI-only; not persisted to DB

**Utilities**

- sanitize-json.ts — circular-reference-safe JSON sanitizer
- abort.ts — unified isAbortError detection across DOMException and Error

**Layout**

- RightApplicationLayout.tsx — extracts RightPanelVerticalRail as a standalone component
  for the collapsed workspace sidebar
- SettingPanel.tsx — adds tooltipSide prop (defaults to "bottom")

**Graph**

- graph.ts — resets outputMessages to only the final message to prevent duplication
  across iterations
- content-parts.ts — removes legacy tool-part helpers; adds replaceTextParts for
  citation-step content replacement

## ✅ Benefits

- Single source of truth for persistence logic
- parts column enables accurate context reconstruction without re-parsing markdown
- Timing and provider metadata computed once, in the right place
- UI hooks are simpler and fully synchronous after stream ends
- Cron-triggered chats now correctly persist structured content

## 🧪 Test checklist

- [ ] Normal chat flow saves message with correct metadata and parts column
- [ ] Stopped/aborted generation saves partial content
- [ ] Error during LLM call saves error state (message not left dangling)
- [ ] Cron agent chat persists complex content parts
- [ ] Action descriptions translate via common i18n namespace
- [ ] Artifact rendering includes surrounding whitespace
- [ ] Migration 013 runs cleanly on existing databases
- [ ] Collapsed workspace sidebar rail renders and navigates correctly
