### PR TITLE
feat: add more resource assets provider and fix export images fit

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/chrome-manifest.json",
   "manifest_version": 3,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "name": "Memorall",
   "description": "Memorall - AI-powered memory and knowledge management browser extension",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "memorall",
   "description": "Memorall - AI-powered memory and knowledge management browser.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "MIT",
   "type": "module",
   "homepage": "https://zrg-team.github.io/memorall",

--- a/runner/hyperframes-preview.html
+++ b/runner/hyperframes-preview.html
@@ -6,6 +6,6 @@
 	<title>Video Preview</title>
 </head>
 <body>
-	<script src="./js/hyperframes-preview.js?v=20260606-export-viewport"></script>
+	<script src="./js/hyperframes-preview.js?v=20260607-tailwind-runtime"></script>
 </body>
 </html>

--- a/runner/js/hyperframes-preview.js
+++ b/runner/js/hyperframes-preview.js
@@ -8,12 +8,14 @@
 // before loading, so GSAP and the HyperFrames runtime load from jsDelivr.
 //
 // LOAD ORDER (guaranteed by renderComposition):
-//   1. GSAP + shader-transitions + Lucide + D3 + Three — external CDN scripts
-//   2. Lucide icon replacement                         — <i data-lucide="...">
-//   3. inline animation script                         — sets window.__timelines["main"] = tl
-//   4. hyperframe.runtime                              — go() reads __timelines on load
+//   1. Tailwind browser compiler, with preflight disabled
+//   2. GSAP + shader-transitions + Lucide + D3 + Three — external CDN scripts
+//   3. Lucide icon replacement                         — <i data-lucide="...">
+//   4. inline animation script                         — sets window.__timelines["main"] = tl
+//   5. hyperframe.runtime                              — go() reads __timelines on load
 
 const DEFAULT_EXPORT_FPS = 30;
+const TAILWIND_BROWSER_URL = "https://cdn.tailwindcss.com";
 const MEDIABUNNY_ESM_URL =
 	"https://cdn.jsdelivr.net/npm/mediabunny@1.45.2/+esm";
 const LUCIDE_UMD_URL =
@@ -28,6 +30,8 @@ const HYPERFRAMES_SHADER_URL =
 	"https://cdn.jsdelivr.net/npm/@hyperframes/shader-transitions@0.6.33/dist/index.global.js";
 const HTML2CANVAS_URL =
 	"https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js";
+const TRANSPARENT_IMAGE_URL =
+	"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E";
 
 // ── CDN fallback map for extension-local script URLs ─────────────────────────
 // Mirrors the CDN_TO_LOCAL map in composition-preprocessor.ts (reversed).
@@ -41,6 +45,7 @@ const CDN_MAP = {
 	"d3.js": D3_UMD_URL,
 	"three.min.js": THREE_GLOBAL_URL,
 	"three.js": THREE_GLOBAL_URL,
+	"tailwind.js": TAILWIND_BROWSER_URL,
 };
 
 function resolveSrc(src) {
@@ -62,6 +67,7 @@ const keyFromLocation = () =>
 const key = keyFromLocation();
 let html2CanvasLoad = null;
 let mediabunnyLoad = null;
+let tailwindLoad = null;
 let currentFilenameBase = "hyperframes-composition";
 let exportInProgress = false;
 const reportedRuntimeErrors = new Set();
@@ -272,6 +278,75 @@ function loadMediabunny() {
 	return mediabunnyLoad;
 }
 
+function configureTailwindRuntime() {
+	window.tailwind = window.tailwind || {};
+	window.tailwind.config = {
+		...(window.tailwind.config || {}),
+		corePlugins: {
+			...window.tailwind.config?.corePlugins,
+			preflight: false,
+		},
+		theme: {
+			...window.tailwind.config?.theme,
+			extend: {
+				...window.tailwind.config?.theme?.extend,
+				colors: {
+					...window.tailwind.config?.theme?.extend?.colors,
+					"hf-bg": "var(--bg)",
+					"hf-ink": "var(--ink)",
+					"hf-accent": "var(--accent)",
+					"hf-accent-2": "var(--accent2)",
+					"hf-muted": "var(--muted)",
+				},
+				fontFamily: {
+					...window.tailwind.config?.theme?.extend?.fontFamily,
+					"hf-display": "var(--font-display)",
+					"hf-data": "var(--font-data)",
+				},
+			},
+		},
+	};
+}
+
+function loadTailwindRuntime() {
+	configureTailwindRuntime();
+	if (document.querySelector(`script[src="${TAILWIND_BROWSER_URL}"]`)) {
+		return Promise.resolve();
+	}
+	tailwindLoad ??= loadScriptOnce(TAILWIND_BROWSER_URL, () =>
+		Boolean(document.querySelector("style[data-tailwind]")),
+	).catch((error) => {
+		reportRuntimeError("resource", formatErrorMessage(error), {
+			tagName: "script",
+			source: TAILWIND_BROWSER_URL,
+		});
+	});
+	return tailwindLoad;
+}
+
+async function waitForTailwindReady() {
+	await waitForRaf();
+	const probe = document.createElement("div");
+	probe.className =
+		"hf-tailwind-probe pointer-events-none absolute w-[13px] h-[7px] bg-[#123456]";
+	probe.setAttribute("data-html2canvas-ignore", "true");
+	probe.style.left = "-9999px";
+	probe.style.top = "-9999px";
+	document.body.appendChild(probe);
+	await waitForRaf();
+	const style = getComputedStyle(probe);
+	const widthOk = Math.round(parseFloat(style.width)) === 13;
+	const colorOk = style.backgroundColor === "rgb(18, 52, 86)";
+	probe.remove();
+	if (!widthOk || !colorOk) {
+		reportRuntimeError(
+			"runtime",
+			"Tailwind styles did not become ready before HyperFrames preview.",
+			{ source: TAILWIND_BROWSER_URL },
+		);
+	}
+}
+
 function runInline(code) {
 	if (!code || !code.trim()) return;
 	const s = document.createElement("script");
@@ -305,6 +380,10 @@ function isD3Script(src) {
 
 function isThreeScript(src) {
 	return /(?:^|\/)three(?:@|\/)|\/three(?:\.min)?\.js(?:\?|$)/i.test(src);
+}
+
+function isTailwindScript(src) {
+	return /cdn\.tailwindcss\.com|tailwind(?:\.browser|\.min)?\.js/i.test(src);
 }
 
 function hasLucidePlaceholders(root = document) {
@@ -342,6 +421,7 @@ const MANAGED_SCRIPT_TESTS = [
 	isLucideScript,
 	isD3Script,
 	isThreeScript,
+	isTailwindScript,
 ];
 
 function isManagedScript(src) {
@@ -505,6 +585,48 @@ function withCompositionExportViewport(width, height) {
 			else el.setAttribute("style", style);
 		}
 	};
+}
+
+function toCssUrl(value) {
+	return `url("${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\a ")}")`;
+}
+
+function objectFitToBackgroundSize(objectFit) {
+	switch (objectFit) {
+		case "cover":
+			return "cover";
+		case "contain":
+		case "scale-down":
+			return "contain";
+		case "none":
+			return "auto";
+		default:
+			return null;
+	}
+}
+
+function preserveObjectFitImagesForHtml2Canvas(clonedDocument) {
+	const clonedWindow = clonedDocument.defaultView;
+	if (!clonedWindow) return;
+
+	for (const img of clonedDocument.querySelectorAll("img")) {
+		const style = clonedWindow.getComputedStyle(img);
+		const backgroundSize = objectFitToBackgroundSize(style.objectFit);
+		if (!backgroundSize) continue;
+
+		const src =
+			img.currentSrc || img.getAttribute("src") || img.getAttribute("data-src");
+		if (!src) continue;
+
+		img.style.backgroundImage = toCssUrl(src);
+		img.style.backgroundSize = backgroundSize;
+		img.style.backgroundPosition = style.objectPosition || "50% 50%";
+		img.style.backgroundRepeat = "no-repeat";
+		img.style.backgroundClip = "padding-box";
+		img.removeAttribute("srcset");
+		img.removeAttribute("sizes");
+		img.setAttribute("src", TRANSPARENT_IMAGE_URL);
+	}
 }
 
 function getRootTimeline() {
@@ -676,6 +798,7 @@ async function exportMp4({ filenameBase, onProgress }) {
 				ignoreElements: (el) =>
 					el.hasAttribute("data-html2canvas-ignore") ||
 					Boolean(el.closest?.("[data-html2canvas-ignore]")),
+				onclone: preserveObjectFitImagesForHtml2Canvas,
 			});
 
 			ctx.clearRect(0, 0, width, height);
@@ -730,18 +853,23 @@ async function renderComposition(html, inlineScripts, options = {}) {
 
 	const scripts = mergeInlineScripts(inlineScripts, extractFromHtml(html));
 
-	// Step 1: GSAP, shader-transitions, Lucide, D3, Three
+	// Step 1: Tailwind browser compiler. Preflight is disabled so existing
+	// direct-CSS compositions do not receive Tailwind base resets.
+	await loadTailwindRuntime();
+	await waitForTailwindReady();
+
+	// Step 2: GSAP, shader-transitions, Lucide, D3, Three
 	for (const src of [...managedScripts.external, ...unmanagedSrcs]) {
 		await loadExternal(src);
 	}
 
-	// Step 2: replace simple Lucide placeholders before animations target them.
+	// Step 3: replace simple Lucide placeholders before animations target them.
 	renderLucideIcons();
 
-	// Step 3: inline animation — sets window.__timelines["main"] = tl
+	// Step 4: inline animation — sets window.__timelines["main"] = tl
 	for (const code of scripts) runInline(code);
 
-	// Step 4: hyperframe.runtime — go() now finds __timelines populated
+	// Step 5: hyperframe.runtime — go() now finds __timelines populated
 	for (const src of managedScripts.runtime) await loadExternal(src);
 	currentFilenameBase = options.filenameBase || currentFilenameBase;
 	postExportStatus({ status: "idle" });

--- a/src/main/components/atoms/copilot/CopilotOverlay.tsx
+++ b/src/main/components/atoms/copilot/CopilotOverlay.tsx
@@ -210,6 +210,7 @@ export const CopilotOverlay: React.FC<CopilotOverlayProps> = ({
 	const isLargeTarget =
 		targetRect.width > window.innerWidth * 0.45 &&
 		targetRect.height > window.innerHeight * 0.7;
+	const shouldUseSpotlight = !isBodyTarget && !isLargeTarget;
 
 	return createPortal(
 		<AnimatePresence>
@@ -229,11 +230,9 @@ export const CopilotOverlay: React.FC<CopilotOverlayProps> = ({
 					e.stopPropagation();
 				}}
 			>
-				{/* Backdrop — solid for body target, spotlight cutout for specific elements */}
+				{/* Backdrop — solid for full-screen targets, spotlight cutout for specific elements */}
 				<div className="absolute inset-0 pointer-events-auto">
-					{isBodyTarget ? (
-						<div className="absolute inset-0 bg-black/60" />
-					) : (
+					{shouldUseSpotlight ? (
 						<svg
 							width="100%"
 							height="100%"
@@ -256,15 +255,17 @@ export const CopilotOverlay: React.FC<CopilotOverlayProps> = ({
 							<rect
 								width="100%"
 								height="100%"
-								fill="rgba(0, 0, 0, 0.5)"
+								fill="rgba(0, 0, 0, 0.55)"
 								mask="url(#copilot-mask)"
 							/>
 						</svg>
+					) : (
+						<div className="absolute inset-0 bg-black/60 backdrop-blur-[1px]" />
 					)}
 				</div>
 
 				{/* Highlight ring — only for specific element targets */}
-				{!isBodyTarget && !isLargeTarget && (
+				{shouldUseSpotlight && (
 					<motion.div
 						initial={{ scale: 0.8, opacity: 0 }}
 						animate={{ scale: 1, opacity: 1 }}
@@ -281,7 +282,7 @@ export const CopilotOverlay: React.FC<CopilotOverlayProps> = ({
 				)}
 
 				{/* Pulsing beacon — only for specific element targets */}
-				{!isBodyTarget && !isLargeTarget && !currentStep.disableBeacon && (
+				{shouldUseSpotlight && !currentStep.disableBeacon && (
 					<motion.div
 						className="absolute w-4 h-4 bg-blue-500 rounded-full"
 						style={{

--- a/src/main/components/atoms/copilot/CopilotTooltip.tsx
+++ b/src/main/components/atoms/copilot/CopilotTooltip.tsx
@@ -244,7 +244,7 @@ export const CopilotTooltip: React.FC<CopilotTooltipProps> = ({
 			}}
 		>
 			<Card
-				className="w-[22.5rem] max-w-[calc(100vw-1rem)] shadow-2xl border border-blue-400/40 bg-background/95 relative pointer-events-auto backdrop-blur-xl"
+				className="w-[22.5rem] max-w-[calc(100vw-1rem)] shadow-2xl border border-blue-400/40 bg-background relative pointer-events-auto"
 				style={{ zIndex: 9500 }}
 			>
 				{/* Arrow */}

--- a/src/services/flows-core/__tests/tools/hyperframes.test.ts
+++ b/src/services/flows-core/__tests/tools/hyperframes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
 	DirEntry,
 	FileStat,
@@ -9,6 +9,14 @@ import {
 	HYPERFRAMES_FEATURE_SYSTEM_PROMPT,
 } from "flow-core/steps/features/hyperframes-feature/hyperframes-feature";
 import { preprocessComposition } from "flow-core/tools/hyperframes/composition-preprocessor";
+import {
+	createHyperframesRemoteAssetImportTool,
+	extractGoogleResolvedImageUrl,
+} from "flow-core/tools/hyperframes/hyperframes-remote-asset-import";
+import {
+	createHyperframesRemoteAssetsExploreTool,
+	extractGoogleImageCandidates,
+} from "flow-core/tools/hyperframes/hyperframes-remote-assets-explore";
 import { lintHyperframesComposition } from "flow-core/tools/hyperframes/hyperframes-validate";
 import { createHyperframesWriteTool } from "flow-core/tools/hyperframes/hyperframes-write";
 import { stepRegistry } from "flow-core/registries/step-registry";
@@ -151,6 +159,11 @@ class MemoryFs implements IFlowFileSystem {
 		await this.stat(path);
 	}
 }
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
 
 describe("HyperFrames composition preprocessing", () => {
 	it("inlines project resource images referenced from HTML, CSS, and JavaScript", async () => {
@@ -301,7 +314,237 @@ describe("HyperFrames feature config", () => {
 	});
 });
 
+describe("HyperFrames remote asset Google Images support", () => {
+	const googleHref =
+		"/imgres?q=anh%20trai%20vuot%20ngan%20chong%20gai%202024%20logo%20png&amp;imgurl=https%3A%2F%2Fatvncgwiki.wiki.gg%2Fvi%2Fimages%2FSite-logo.png%3F7ec62e&amp;imgrefurl=https%3A%2F%2Fatvncgwiki.wiki.gg%2F&amp;docid=nd3gVdWcnqg3vM&amp;tbnid=nCRrGu_3WlNDmM&amp;w=287&amp;h=287";
+
+	it("extracts Google Images /imgres candidates with alt text and metadata", () => {
+		const candidates = extractGoogleImageCandidates({
+			baseUrl: "https://www.google.com/search?udm=2&q=logo",
+			maxResults: 5,
+			html: `
+				<html><head><title>Google Images</title></head><body>
+					<a href="${googleHref}">
+						<div>
+							<img src="data:image/jpeg;base64,abc" alt="Anh Trai Vượt Ngàn Chông Gai Wiki" height="225" width="225">
+						</div>
+					</a>
+				</body></html>
+			`,
+		});
+
+		expect(candidates).toHaveLength(1);
+		expect(candidates[0]).toEqual(
+			expect.objectContaining({
+				provider: "google_images",
+				url: expect.stringContaining("https://www.google.com/imgres?"),
+				sourceUrl: "https://atvncgwiki.wiki.gg/",
+				imageUrlPreview:
+					"https://atvncgwiki.wiki.gg/vi/images/Site-logo.png?7ec62e",
+				alt: "Anh Trai Vượt Ngàn Chông Gai Wiki",
+				width: 287,
+				height: 287,
+			}),
+		);
+	});
+
+	it("resolves the actual image URL from rendered Google imgres HTML", () => {
+		const resolved = extractGoogleResolvedImageUrl({
+			baseUrl: "https://www.google.com/imgres?q=logo",
+			googleResultUrl:
+				"https://www.google.com/imgres?q=logo&imgurl=https%3A%2F%2Fexample.com%2Ffallback.png",
+			html: `
+				<div jsname="figiqf">
+					<a href="https://atvncgwiki.wiki.gg/">
+						<img src="https://atvncgwiki.wiki.gg/vi/images/Site-logo.png?7ec62e" class="sFlh5c FyHeAf iPVvYb" alt="Anh Trai Vượt Ngàn Chông Gai Wiki" jsname="kn3ccd">
+						<img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRIlMqiapZK41p7VOqsTeg3QQYVUH-0s3-ixQ&amp;s" class="sFlh5c FyHeAf" alt="thumbnail">
+					</a>
+				</div>
+			`,
+		});
+
+		expect(resolved).toBe(
+			"https://atvncgwiki.wiki.gg/vi/images/Site-logo.png?7ec62e",
+		);
+	});
+
+	it("falls back to the decoded imgurl query parameter during Google import", async () => {
+		const fs = new MemoryFs({});
+		const googleUrl =
+			"https://www.google.com/imgres?q=logo&imgurl=https%3A%2F%2Fexample.com%2Flogo.png&imgrefurl=https%3A%2F%2Fexample.com%2F&w=287&h=287";
+		const webBrowser = {
+			openSession: vi.fn(async () => ({
+				session: {
+					id: "google-session",
+					currentUrl: googleUrl,
+					html: "<html><body>No usable image yet</body></html>",
+					text: "",
+				},
+			})),
+			waitForPageRender: vi.fn(async () => ({ matched: true })),
+			refreshSession: vi.fn(async () => ({
+				id: "google-session",
+				currentUrl: googleUrl,
+				html: "<html><body>No usable image yet</body></html>",
+				text: "",
+			})),
+			closeSession: vi.fn(async () => undefined),
+		};
+		const fetchMock = vi.fn(async (url: string) => {
+			expect(url).toBe("https://example.com/logo.png");
+			return new Response(new Uint8Array([1, 2, 3]), {
+				status: 200,
+				headers: { "content-type": "image/png" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const tool = createHyperframesRemoteAssetImportTool(
+			{ fs, webBrowser } as never,
+			{ rootPath: "/projects" },
+		);
+		const result = JSON.parse(
+			String(await tool.execute({
+				project_path: "demo",
+				url: googleUrl,
+				asset_path: "images/logo.png",
+			})),
+		);
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				success: true,
+				file_path: "/projects/demo/resources/images/logo.png",
+				html_src: "./resources/images/logo.png",
+				resolvedImageUrl: "https://example.com/logo.png",
+				mimeType: "image/png",
+			}),
+		);
+		await expect(
+			fs.readFile("/projects/demo/resources/images/logo.png"),
+		).resolves.toEqual(new Uint8Array([1, 2, 3]));
+	});
+
+	it("continues to fallback providers when Google is blocked", async () => {
+		const openedUrls: string[] = [];
+		const webBrowser = {
+			openSession: vi.fn(async ({ url }: { url: string }) => {
+				openedUrls.push(url);
+				if (openedUrls.length === 1) {
+					return {
+						session: {
+							id: "google-session",
+							currentUrl: url,
+							html: "Our systems have detected unusual traffic",
+							text: "Our systems have detected unusual traffic",
+						},
+					};
+				}
+				throw new Error("stop after proving fallback");
+			}),
+			waitForPageRender: vi.fn(async () => ({ matched: true })),
+			refreshSession: vi.fn(async () => ({
+				id: "google-session",
+				currentUrl: openedUrls[0],
+				html: "Our systems have detected unusual traffic",
+				text: "Our systems have detected unusual traffic",
+			})),
+			closeSession: vi.fn(async () => undefined),
+		};
+		const tool = createHyperframesRemoteAssetsExploreTool(
+			{ webBrowser } as never,
+			{},
+		);
+
+		const result = JSON.parse(
+			String(await tool.execute({
+				query: "sample logo",
+				max_results: 2,
+				min_results: 2,
+			})),
+		);
+
+		expect(openedUrls[0]).toContain("https://www.google.com/search?");
+		expect(openedUrls[0]).toContain("udm=2");
+		expect(openedUrls[1]).toContain("https://www.cleanpng.com/free/");
+		expect(result.attempts[0]).toEqual(
+			expect.objectContaining({
+				provider: "google_images",
+				success: false,
+				reason: "unusual_traffic",
+			}),
+		);
+	});
+
+	it("keeps direct image imports working without a browser service", async () => {
+		const fs = new MemoryFs({});
+		const fetchMock = vi.fn(async (url: string) => {
+			expect(url).toBe("https://example.com/direct.png");
+			return new Response(new Uint8Array([9, 8, 7]), {
+				status: 200,
+				headers: { "content-type": "image/png" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const tool = createHyperframesRemoteAssetImportTool(
+			{ fs } as never,
+			{ rootPath: "/projects" },
+		);
+		const result = JSON.parse(
+			String(await tool.execute({
+				project_path: "demo",
+				url: "https://example.com/direct.png",
+			})),
+		);
+
+		expect(result).toEqual(
+			expect.objectContaining({
+				success: true,
+				url: "https://example.com/direct.png",
+				finalUrl: "https://example.com/direct.png",
+			}),
+		);
+		expect(result).not.toHaveProperty("resolvedImageUrl");
+	});
+});
+
 describe("HyperFrames validation", () => {
+	it("accepts Tailwind-authored static classes including arbitrary values", async () => {
+		const fs = new MemoryFs({});
+		const result = await lintHyperframesComposition(
+			`
+				<!doctype html>
+				<html lang="en">
+					<head><meta charset="UTF-8" /></head>
+					<body>
+						<div id="main" data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="3">
+							<div id="s1" class="scene clip absolute inset-0 w-[1920px] h-[1080px] bg-[#08080f] grid grid-cols-[1fr_480px]" data-start="0" data-duration="3" data-track-index="0">
+								<div class="flex items-center justify-center text-hf-ink">Tailwind scene</div>
+							</div>
+						</div>
+						<script>
+							window.__timelines = window.__timelines || {};
+							var tl = gsap.timeline({ paused: true });
+							window.__timelines["main"] = tl;
+						</script>
+					</body>
+				</html>
+			`,
+			fs,
+			"/projects/demo",
+		);
+
+		expect(result.ok).toBe(true);
+		expect(result.findings).not.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: expect.stringMatching(/^tailwind_|^manual_tailwind/),
+				}),
+			]),
+		);
+	});
+
 	it("reports HyperShader scene and transition count mismatches", async () => {
 		const fs = new MemoryFs({});
 		const result = await lintHyperframesComposition(
@@ -343,6 +586,67 @@ describe("HyperFrames validation", () => {
 				expect.objectContaining({
 					code: "missing_local_image_asset",
 					message: expect.stringContaining("temple-sign-buddha.jpeg"),
+				}),
+			]),
+		);
+	});
+
+	it("warns when a composition includes a manual Tailwind loader", async () => {
+		const fs = new MemoryFs({});
+		const result = await lintHyperframesComposition(
+			`<script src="https://cdn.tailwindcss.com"></script>`,
+			fs,
+			"/projects/demo",
+		);
+
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "manual_tailwind_loader",
+					severity: "warning",
+				}),
+			]),
+		);
+	});
+
+	it("warns when JavaScript builds Tailwind classes dynamically", async () => {
+		const fs = new MemoryFs({});
+		const result = await lintHyperframesComposition(
+			`<script>el.className = "bg-" + color;</script>`,
+			fs,
+			"/projects/demo",
+		);
+
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "dynamic_tailwind_class",
+					severity: "warning",
+				}),
+			]),
+		);
+	});
+
+	it("warns on Tailwind and CSS animation utilities", async () => {
+		const fs = new MemoryFs({});
+		const result = await lintHyperframesComposition(
+			`
+				<style>.pulse{animation:pulse 1s infinite}</style>
+				<div class="animate-pulse"></div>
+			`,
+			fs,
+			"/projects/demo",
+		);
+
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					code: "tailwind_animation_class",
+					severity: "warning",
+				}),
+				expect.objectContaining({
+					code: "css_animation_property",
+					severity: "warning",
 				}),
 			]),
 		);

--- a/src/services/flows-core/steps/features/fs-feature.ts
+++ b/src/services/flows-core/steps/features/fs-feature.ts
@@ -39,82 +39,23 @@ export type FsFeatureServices = {};
 // ============================================================================
 
 const SYSTEM_PROMPT_INSTRUCTION = `
-# FILESYSTEM ACCESS (v2)
-You have access to filesystem-style tools. Paths are absolute virtual paths
-provided by the host runtime.
+# FILESYSTEM ACCESS
 
-## TOOLS OVERVIEW
+## DISCOVERY STRATEGY
+- Start broad: glob or ls to understand structure, then narrow with grep before reading.
+- Combine alternatives in a single call rather than repeating with small variations.
+- Use grep's \`output_mode: "files_with_matches"\` to get candidate paths first, then read only what you need.
+- Use grep's \`context\` lines and glob/type filters to reduce noise in a single pass.
 
-| Tool | Purpose |
-|---|---|
-| \`fs_ls\` | List files and directories at a path |
-| \`fs_glob\` | Find files matching a glob pattern |
-| \`fs_grep\` | Search file content by regex pattern |
-| \`fs_read\` | Read a file with line numbers |
-| \`fs_write\` | Create or overwrite a file |
-| \`fs_edit\` | Replace exact text inside a file |
-| \`fs_mkdir\` | Create a directory |
-| \`fs_remove\` | Delete a file or directory |
+## READ / EDIT STRATEGY
+- Always read a file before editing — you need the exact text to match.
+- Prefer targeted edits over full rewrites; use \`replace_all\` only when renaming across the file.
+- For large files, read in chunks with \`offset\` / \`limit\` rather than loading everything.
+- After writing or editing, only mention the file path — do not echo its content.
 
-## RECOMMENDED WORKFLOWS
-
-### Exploring the filesystem
-1. Use \`fs_ls\` to inspect a known root or directory.
-2. Use \`fs_glob\` with a pattern like \`**/*.md\` scoped to a known root.
-3. Use \`fs_grep\` to locate files containing specific content before reading.
-
-### Reading files
-- Use \`fs_read\` to read a file. It returns content with line numbers (cat -n style).
-- For large files, use \`offset\` and \`limit\` to read in chunks (e.g. offset: 1, limit: 100).
-- Always read a file before editing it — you need to see the current content.
-
-### Creating or updating files
-- \`fs_write\` creates a new file or **fully overwrites** an existing one.
-- \`fs_edit\` replaces an exact string within an existing file. Use for targeted edits.
-  - \`old_string\` must match exactly (including whitespace and newlines).
-  - Set \`replace_all: true\` to replace every occurrence; default replaces only the first.
-- After writing or editing a file, do not include the file content in assistant message content. Only mention the path of the file that was created or updated.
-
-### Searching content
-- \`fs_grep\` accepts a regex \`pattern\` and returns results in \`file:line:content\` format.
-- Use \`glob\` to restrict the search to specific file types (e.g. \`"*.ts"\`, \`"**/*.md"\`).
-- Use \`context\` (number of surrounding lines) to get more context around each match.
-- Use \`output_mode: "files_with_matches"\` to get only file paths, or \`"count"\` for match counts.
-- For ambiguous content searches, combine likely terms in one regex and likely file types in one glob:
-  - \`fs_grep pattern="icon|logo|brand" glob="**/*.{ts,tsx,js,jsx,json,md,svg,html,css}" path="/"\`
-- Prefer \`output_mode: "files_with_matches"\` first when you only need candidate paths, then read the best matching files.
-- Do not repeat several \`fs_grep\` calls that only vary one word or one extension; use regex alternatives and glob alternatives.
-
-### Finding files by name/pattern
-- \`fs_glob\` accepts glob syntax:
-  - \`*\` matches anything in a single directory segment.
-  - \`**\` matches across any number of directory levels.
-  - \`?\` matches any single character.
-  - \`{a,b}\` matches alternatives; use it to combine likely names or extensions in one call.
-  - \`[abc]\` and \`[!abc]\` match character sets.
-  - \`@(a|b)\` matches one of the alternatives.
-- Example: \`fs_glob pattern="**/*.ts" path="/"\`
-
-### Efficient file discovery
-- When the user asks for a file by concept, name fragment, brand, logo, icon, asset, image, or extension, do not repeat many narrow \`fs_glob\` calls.
-- Combine likely filename terms and likely extensions in a single glob. Example for finding an icon/logo:
-  - \`fs_glob pattern="**/*{icon,logo,brand}*.{png,jpg,jpeg,svg,webp,ico}" path="/"\`
-- If a combined glob returns no matches, broaden once by changing one dimension at a time:
-  1. Broaden names: \`**/*{icon,logo,brand,image,asset}*.{png,jpg,jpeg,svg,webp,ico}\`
-  2. Broaden extensions: \`**/*{icon,logo,brand}*.*\`
-  3. List nearby directories with \`fs_ls\` only when glob results suggest a likely folder.
-- Do not search only one extension such as \`.svg\` unless the user explicitly asked for that extension.
-- Do not retry the same failed pattern in another wording; change the root, name alternatives, extension alternatives, or use \`fs_ls\` for structure.
-
-### Organizing files
-- \`fs_mkdir\` creates a directory (recursive by default — parent dirs are created automatically).
-- \`fs_remove\` deletes a file. To delete a non-empty directory, pass \`recursive: true\`.
-
-## IMPORTANT RULES
-- Always use \`fs_read\` before \`fs_edit\` — verify the exact text to replace.
-- Prefer \`fs_edit\` over \`fs_write\` when modifying a small portion of a large file.
-- Use \`fs_grep\` before reading large files to confirm they contain what you need.
-- The host runtime defines persistence and write permissions for available paths.
+## WRITE / DELETE STRATEGY
+- Writes fully overwrite — use only for new files or intentional full replacements.
+- Deletes are irreversible; confirm the path is correct before removing.
 `;
 
 export const FS_FEATURE_SYSTEM_PROMPT = SYSTEM_PROMPT_INSTRUCTION.trim();

--- a/src/services/flows-core/steps/features/hyperframes-feature/hyperframes-feature.ts
+++ b/src/services/flows-core/steps/features/hyperframes-feature/hyperframes-feature.ts
@@ -38,7 +38,7 @@ export type HyperframesFeatureServices = Record<string, never>;
 const SYSTEM_PROMPT_INSTRUCTION = `
 # HYPERFRAMES VIDEO COMPOSER
 
-Your medium is **HyperFrames compositions**: plain HTML + CSS + a paused GSAP timeline.
+Your medium is **HyperFrames compositions**: HTML with Tailwind classes, a small CSS escape hatch, and a paused GSAP timeline.
 Everything runs in the browser — no CLI, no Node.js required.
 The HyperFrames preview includes playback controls and MP4 export/download support.
 
@@ -56,37 +56,24 @@ toolbar after \`hyperframes_show\`.
 
 ## Tool strategy
 
-### Core composition lifecycle
+Execute tool sequences immediately — never describe, explain, or ask first.
 
-**Starting a new project** — always run this full sequence, never skip steps:
-\`hyperframes_init\` → \`hyperframes_write\` → \`hyperframes_validate\` → \`hyperframes_show\`
-
-**Editing or fixing anything** — read first so you never lose existing work:
-\`hyperframes_read\` → \`hyperframes_write\` → \`hyperframes_validate\` → \`hyperframes_show\`
-
-**Previewing only** — when the user asks to "show", "preview", or "play" without changes:
-\`hyperframes_show\` only
+| Goal | Tool sequence — run immediately |
+|---|---|
+| **Start a project (known topic/place/brand)** | web_search (research) → remote_assets_explore → init (Step 2 template) → write → validate → show |
+| **Start a project (assets provided)** | init (Step 2 template) → write → validate → show |
+| **Update / edit / fix** | read → write → validate → show |
+| **Verify a scene** | capture_frame → inspect visually |
+| **Show the user** | show |
 
 Never write without reading first on an existing project. Never show without validating first.
 Run \`hyperframes_validate\` before every \`hyperframes_show\`. If it reports errors, fix them and re-write before showing — never show a broken composition.
 
-### Discovering local assets
+Prefer \`hyperframes_edit\` over \`hyperframes_write\` when changing a small portion of an existing composition — pass the exact text to replace as \`old_string\`. Use \`hyperframes_write\` only for new projects (after init) or full rewrites.
 
-Use these **before** inventing visuals or reaching for remote assets. Always check local first:
+Always check local assets before inventing visuals or reaching for remote assets. Use \`fs_ls\` / \`fs_glob\` / \`fs_grep\` / \`fs_read\` — see Step 1 for patterns.
 
-1. **\`fs_ls\`** — orient yourself: list the target \`project_path\` or available root paths to see what exists.
-2. **\`fs_glob\`** — hunt for images, logos, or brand files by pattern (e.g. \`**/*.{png,jpg,svg}\`, \`**/*logo*\`). Use this before \`fs_read\` to avoid reading entire directories blind.
-3. **\`fs_grep\`** — find a specific string inside files: brand hex codes, color tokens, product names, or asset references. Much faster than reading every file.
-4. **\`fs_read\`** — open a specific text file (brief, markdown, CSS, SVG, brand notes) only after \`fs_glob\`/\`fs_grep\` have identified it. Never use it on binary images.
-
-### Sourcing remote assets
-
-Use remote assets only when local/user assets are missing or too weak. Always a two-step pair — never hotlink directly:
-
-1. **\`hyperframes_remote_assets_explore(query, kind?)\`** — searches free image sources (CleanPNG first, then Openverse, Pexels, Unsplash; SVG Repo first for vectors). Returns scored candidates with a \`sessionId\`. Use \`kind\` to steer: \`"image"\`/\`"photo"\` for backgrounds, \`"svg"\`/\`"icon"\` for vectors, \`"any"\` for best available.
-2. **\`hyperframes_remote_asset_import(project_path, url, sessionId, asset_path)\`** — downloads the chosen candidate into \`{project_path}/resources/\` and returns the \`html_src\` path to reference in HTML.
-
-The composition file is always \`{project_path}/index.html\`.
+Use remote assets only when local assets are missing or too weak. Always an explore → import pair — never hotlink directly. The composition file is always \`{project_path}/index.html\`. See Step 1 for workflow.
 
 ### Asset path rules
 
@@ -95,21 +82,17 @@ The composition file is always \`{project_path}/index.html\`.
 - **Static HTML only.** The host runtime converts \`<img src>\`, SVG \`<image href>\`, \`video poster\`, and CSS \`url(...)\` to base64 — only static HTML attributes, never JavaScript-assigned values.
 - **No JS asset loading of any kind.** Never build, assemble, fetch, or assign an image path in JavaScript. Helper functions (\`fixIconPath\`, \`getAssetUrl\`), path concatenation (\`'./resources/' + name\`), \`fetch()\`, \`new Image()\`, and \`img.src = anyPath\` are all forbidden. If JavaScript must reference an asset: declare it once as \`<img id="pre" src="<absolute-path>" hidden>\` in HTML, then read \`document.getElementById('pre').src\` in JS — the host has already replaced it with base64 by that point. For repeated icons, prefer inline SVG markup.
 - **No remote hotlinks.** Import remote media with \`hyperframes_remote_asset_import\` first; use the returned path.
-- **No manual \`<script>\` tags or external \`<link>\` tags.** GSAP, HyperFrames runtime, shader-transitions, Lucide, D3, and Three.js are auto-injected by the runner based on usage detection. Never include CDN script tags or Google Fonts link tags in compositions — the runner handles all of this automatically.
+- **No manual \`<script>\` tags or external \`<link>\` tags.** GSAP, HyperFrames runtime, shader-transitions, Lucide, D3, Three.js, and Tailwind are auto-injected by the runner based on usage detection. Never include CDN script tags, Tailwind CDN tags, Tailwind CSS links, or Google Fonts link tags in compositions — the runner handles all of this automatically.
 
-## Agent goals
+### Tailwind authoring
 
-Execute tool sequences immediately — never describe, explain, or ask first.
+Use Tailwind classes as the default styling language. The agent writes readable literal classes; the preview runner always loads the official Tailwind browser compiler with preflight disabled and generates the CSS internally.
 
-| Goal | Tool sequence — run immediately |
-|---|---|
-| **Start a project (known topic/place/brand)** | web_search (research) → remote_assets_explore → init → write → validate → show |
-| **Start a project (assets provided)** | init → write → validate → show |
-| **Update / edit / fix** | read → write → validate → show |
-| **Verify a scene** | capture_frame → inspect visually |
-| **Show the user** | show |
-
----
+- Prefer Tailwind for layout, spacing, typography, sizing, color, borders, opacity, z-index, flex/grid, object fit, overflow, and fixed video layouts.
+- Use literal class strings in HTML. Do not build classes dynamically in JavaScript with concatenation, template interpolation, helper functions, or \`classList.add(...dynamic)\`; Tailwind cannot reliably generate CSS for unknown runtime strings.
+- Keep a small \`<style>\` block only for \`:root\` variables, exact \`html,body\` dimensions, complex gradients, masks, grain, custom CSS variables, and one-off selectors that would be less clear as utilities.
+- Use semantic HyperFrames theme utilities when possible: \`bg-hf-bg\`, \`text-hf-ink\`, \`text-hf-accent\`, \`text-hf-muted\`, \`font-hf-display\`, \`font-hf-data\`.
+- Arbitrary values are allowed when they reduce CSS: \`w-[1920px]\`, \`h-[1080px]\`, \`bg-[#08080f]\`, \`grid-cols-[1fr_480px]\`.
 
 ## Your role
 
@@ -151,13 +134,10 @@ If the prompt has none of: an attachment, hex code, named typeface, named aesthe
 
 Before inventing visuals, look for existing assets when the user mentions a product, brand, logo, screenshot, app, file, folder, or prior project:
 
-1. Use \`fs_ls\` on likely roots and the target \`project_path\`.
-2. Use \`fs_glob\` for assets:
-   - \`**/*.{png,jpg,jpeg,webp,gif,svg,ico}\`
-   - \`**/*{logo,icon,brand,mark,screenshot,hero,asset}*\`
-   - \`**/*.{md,txt,json,css,html}\` for brand notes and source references.
-3. Use \`fs_grep\` for product names, color variables, slogans, image filenames, or CSS tokens before reading large files.
-4. Use \`fs_read\` only for text-like files. Do not read binary images with \`fs_read\`.
+- Glob for images/brand: \`**/*.{png,jpg,jpeg,webp,gif,svg,ico}\`, \`**/*{logo,icon,brand,mark,screenshot,hero,asset}*\`
+- Glob for brand text: \`**/*.{md,txt,json,css,html}\`
+- Grep for color variables, product names, slogans, or CSS tokens before reading large files.
+- Read only confirmed text files — never use \`fs_read\` on binary images.
 
 Use discovered images directly in the composition with the exact absolute path returned by the filesystem tools.
 
@@ -177,18 +157,10 @@ If local/user assets are missing or too weak for the video, use \`hyperframes_re
 Workflow:
 
 1. Call \`hyperframes_remote_assets_explore({ query, kind })\`.
-2. The tool tries supported sources in the best order and falls back automatically when a source is blocked or has too few candidates.
-3. Pick a strong \`candidate.url\` from the result.
+2. The tool tries Google Images first, then falls back automatically to the other supported sources when Google is blocked, requires consent/CAPTCHA, or has too few usable candidates.
+3. Pick a strong \`candidate.url\` from the result. For Google Images candidates, \`candidate.url\` is a Google \`/imgres\` result page and \`imageUrlPreview\` is informational only.
 4. Call \`hyperframes_remote_asset_import({ project_path, url: candidate.url, sessionId, asset_path })\` using the returned \`sessionId\`.
 5. Save remote assets inside \`{project_path}/resources/...\`, then use the returned \`html_src\` such as \`./resources/images/vietnam-hero.jpg\` in the HyperFrames HTML. Prefer imported project-local assets over remote hotlinks.
-
-Remote source strategy:
-
-| Need | Query kind | Source priority |
-|---|---|---|
-| Editorial/photo backgrounds | \`image\` or \`photo\` | Openverse → Pexels → Unsplash |
-| Icons, simple SVGs, vector symbols | \`svg\` or \`icon\` | SVG Repo → Openverse → Pexels → Unsplash |
-| Flexible visual fallback | \`any\` | Best supported order from the tool |
 
 Rules:
 
@@ -247,7 +219,7 @@ Three.js rules:
 
 - Use Three.js for procedural 3D only: primitives, particles, lights, fog, camera moves, gradients, panels, rings, grids, and simple materials.
 - Do not require external models, GLB/GLTF, textures, HDRIs, loaders, module imports, or import maps.
-- Do not use \`requestAnimationFrame\`, \`Date.now()\`, \`performance.now()\`, clocks, or async render loops.
+- Do not use \`requestAnimationFrame\`, independent clocks, or async render loops — see Determinism rules.
 - Render from explicit timeline time: \`renderThree(tl.time())\` or a GSAP \`onUpdate\`.
 - Always size the renderer from the composition dimensions, use \`alpha:true\`, and call \`renderer.render(scene,camera)\` after every seek/update.
 - Use Three sparingly: one strong procedural 3D scene is better than every scene becoming a canvas.
@@ -260,16 +232,27 @@ Use case guidance:
 
 ---
 
-## Step 2: Pick a skeleton
+## Step 2: Scaffold with \`hyperframes_init\`
 
-| Type | Duration | Scenes | Skeleton |
-|---|---|---|---|
-| Social reel (9:16) | 10-15s | 5-7 | A |
-| Launch teaser (16:9) | 15-25s | 7-10 | B |
-| Product explainer (16:9) | 30-60s | 10-18 | C |
-| Cinematic title (16:9) | 45-90s | 7-12 | D |
+Always call \`hyperframes_init\` with the right template — never write boilerplate HTML by hand. Then \`hyperframes_read\` to inspect it, and \`hyperframes_write\` to add your content, palette, and animations.
 
-Fill \`:root\` CSS custom properties immediately:
+**Use a scaffold template** when the brief calls for 6+ scenes, a specific duration/format, or a fully custom visual style. Scaffold templates have correct scene wiring, autoAlpha toggles, and HyperShader groups already set up — you supply all content, palette, and animations via \`hyperframes_write\`.
+
+**Use a styled template** when 5 scenes fit the brief and the template's aesthetic is close enough to adapt. They have working entrance animations and palette — override \`:root\` variables and scene content via \`hyperframes_write\`.
+
+| Format | Template |
+|---|---|
+| Social reel (9:16, 15s, 6 scenes) | \`scaffold-social-reel\` |
+| Launch teaser (16:9, 25s, 8 scenes) | \`scaffold-launch-teaser\` |
+| Product explainer (16:9, 45s, 12 scenes) | \`scaffold-explainer\` |
+| Cinematic title (16:9, 60s, 7 scenes) | \`scaffold-cinematic\` |
+| Dark/neon styled (5 scenes) | \`neon-launch\` |
+| Bold vertical styled (5 scenes) | \`social-reel\` |
+| Light editorial styled (5 scenes) | \`clean-minimal\` |
+| Teal/tech styled (5 scenes) | \`tech-data\` |
+| Amber cinematic styled (5 scenes) | \`warm-cinema\` |
+
+Override \`:root\` CSS custom properties to apply your palette:
 
 \`\`\`css
 :root {
@@ -400,6 +383,7 @@ After showing, write one short sentence to the user: what the composition covers
 |---|---|
 | Exit tweens before shader | Shader IS the exit |
 | \`requestAnimationFrame\` | GSAP tweens |
+| Tailwind \`animate-*\` utilities or CSS \`animation:\` | GSAP timeline tweens |
 | CSS \`transform\` for centering | Flexbox centering |
 | SVG filter \`data:image/svg+xml\` grain | CSS radial-gradient grain |
 | \`visibility\` / \`display\` animation | \`autoAlpha\` |
@@ -407,6 +391,7 @@ After showing, write one short sentence to the user: what the composition covers
 **Self-review checklist:**
 
 - [ ] Every scene: \`class="scene clip"\` + all data attributes + \`<div class="scene-content">\`
+- [ ] Tailwind classes are literal HTML class strings, not built dynamically in JavaScript
 - [ ] Anchor scenes: \`style="opacity:0;"\` — Non-anchor: \`style="visibility:hidden;"\`
 - [ ] Every non-anchor has \`autoAlpha\` toggles
 - [ ] First anchor per shader group has explicit \`tl.set({ opacity:1 }, startTime)\`
@@ -418,83 +403,7 @@ After showing, write one short sentence to the user: what the composition covers
 - [ ] D3, if used, generates geometry only; no \`d3.transition()\`, timers, or independent animation clocks
 - [ ] Three.js, if used, is procedural, asset-free, and rendered from GSAP/HyperFrames time; no \`requestAnimationFrame\` loop
 - [ ] No JavaScript assigns, builds, fetches, or loads image paths — every asset is a static \`<img src="<absolute-path>">\` in HTML, or inline SVG markup; no helper functions like \`fixIconPath\`, \`getAssetUrl\`, \`new Image()\`, or \`fetch()\` for images
-
----
-
-## Skeletons
-
-### Skeleton A — Social Reel (1080X1920, 15s, 6 scenes)
-
-\`\`\`html
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=1080, height=1920" />
-    <style>
-      :root { --bg:#0a0a0d;--ink:#f5f5f7;--accent:#7c6cff;--muted:#5a6270;--accent-dim:#3d3680;--font-display:"Space Grotesk",sans-serif;--font-data:"JetBrains Mono",monospace; }
-      *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
-      html,body{width:1080px;height:1920px;overflow:hidden;background:var(--bg);color:var(--ink)}
-      .scene{position:absolute;top:0;left:0;width:1080px;height:1920px;overflow:hidden}
-      .scene-content{width:100%;height:100%;padding:120px 80px;display:flex;flex-direction:column;justify-content:center;gap:24px;box-sizing:border-box;position:relative;z-index:1}
-      .display{font-family:var(--font-display);font-weight:700;line-height:1.1}
-      .body-text{font-family:var(--font-display);font-weight:300;line-height:1.4;color:var(--muted)}
-      .data-text{font-family:var(--font-data);font-weight:400;font-variant-numeric:tabular-nums}
-      .grain{position:absolute;inset:0;pointer-events:none;z-index:50;opacity:0.18;background-image:radial-gradient(rgba(255,255,255,0.08) 1px,transparent 1.2px),radial-gradient(rgba(0,0,0,0.18) 1px,transparent 1.2px);background-size:3px 3px,5px 5px;background-position:0 0,1px 2px;mix-blend-mode:overlay}
-    </style>
-  </head>
-  <body>
-    <div id="main" data-composition-id="main" data-width="1080" data-height="1920" data-start="0" data-duration="15">
-      <div class="scene clip" id="s1" data-start="0" data-duration="2.5" data-track-index="0">
-        <div class="grain"></div><div class="scene-content"><!-- FILL: hook --></div>
-      </div>
-      <div class="scene clip" id="s2" data-start="2.5" data-duration="2.5" data-track-index="0" style="visibility:hidden;">
-        <div class="grain"></div><div class="scene-content"><!-- FILL: context --></div>
-      </div>
-      <!-- SHADER ANCHOR -->
-      <div class="scene clip" id="s3" data-start="5" data-duration="2.5" data-track-index="0" style="opacity:0;">
-        <div class="grain"></div><div class="scene-content"><!-- FILL: build-up --></div>
-      </div>
-      <!-- SHADER ANCHOR -->
-      <div class="scene clip" id="s4" data-start="7.5" data-duration="2.5" data-track-index="0" style="opacity:0;">
-        <div class="grain"></div><div class="scene-content"><!-- FILL: hero --></div>
-      </div>
-      <div class="scene clip" id="s5" data-start="10" data-duration="2.5" data-track-index="0" style="visibility:hidden;">
-        <div class="grain"></div><div class="scene-content"><!-- FILL: proof --></div>
-      </div>
-      <div class="scene clip" id="s6" data-start="12.5" data-duration="2.5" data-track-index="0" style="visibility:hidden;">
-        <div class="grain"></div><div class="scene-content"><!-- FILL: CTA --></div>
-      </div>
-    </div>
-    <script>
-      window.__timelines = window.__timelines || {};
-      if (window.lucide) window.lucide.createIcons();
-      var tl = gsap.timeline({ paused: true });
-      tl.set("#s1",{ autoAlpha:0 },2.5);
-      tl.set("#s2",{ autoAlpha:1 },2.5); tl.set("#s2",{ autoAlpha:0 },5.0);
-      tl.set("#s3",{ opacity:1 },5.0); // first anchor — explicit show required
-      tl.set("#s5",{ autoAlpha:1 },10.0); tl.set("#s5",{ autoAlpha:0 },12.5);
-      tl.set("#s6",{ autoAlpha:1 },12.5);
-      // === FILL: scene animations ===
-      window.HyperShader.init({
-        bgColor:getComputedStyle(document.documentElement).getPropertyValue("--bg").trim()||"#0a0a0d",
-        scenes:["s3","s4"], timeline:tl,
-        transitions:[{time:7.25,shader:"cinematic-zoom",duration:0.5}],
-      });
-      window.__timelines["main"] = tl;
-    </script>
-  </body>
-</html>
-\`\`\`
-
-### Skeleton B — Launch Teaser (1920X1080, 25s, 8 scenes)
-Same structure as A but landscape 1920X1080. 8 scenes totaling 25s. 2 shader anchor groups (s4-s5, s7-s8). Rhythm: \`3-3-3-3.5-3-3-3-3.5\`.
-
-### Skeleton C — Product Explainer (1920X1080, 45s, 12 scenes)
-Same structure as B. 12 scenes totaling 45s. Mix durations: 3s, 3.5s, 4s, 5s. Rhythm: \`3-3-4-3.5-4-5-3.5-4-3.5-4-4-3.5\`.
-
-### Skeleton D — Cinematic Title (1920X1080, 60s, 7 scenes)
-Same structure as B. 7 scenes, longer durations (6-10s each). Restrained shaders: \`cross-warp-morph\`, \`thermal-distortion\`. Rhythm: \`8-7-8-10-9-10-8\`.
+- [ ] No Tailwind CDN/link tags and no \`animate-*\` utilities; all timeline motion uses GSAP/HyperShader
 
 ---
 
@@ -616,6 +525,7 @@ export const HYPERFRAMES_FEATURE_SYSTEM_PROMPT =
 export const HYPERFRAMES_FEATURE_TOOLS = [
 	"hyperframes_init",
 	"hyperframes_write",
+	"hyperframes_edit",
 	"hyperframes_read",
 	"hyperframes_validate",
 	"hyperframes_show",

--- a/src/services/flows-core/tools/hyperframes/hyperframes-edit.ts
+++ b/src/services/flows-core/tools/hyperframes/hyperframes-edit.ts
@@ -1,0 +1,84 @@
+import z from "zod";
+import type { Tool, ToolFactory } from "flow-core/interfaces/engine/tool";
+import type { AllServices } from "flow-core/interfaces/services/services";
+import { toolRegistry } from "flow-core/registries/tool-registry";
+import { compositionFile } from "flow-core/tools/hyperframes/util";
+import { readFileBytes, writeFileBytes } from "flow-core/tools/fs/util";
+import type { HyperframesToolConfig } from "flow-core/tools/hyperframes/config";
+
+const TOOL_NAME = "hyperframes_edit" as const;
+
+const schema = z.object({
+	project_path: z
+		.string()
+		.min(1)
+		.describe(
+			"Absolute path to the project directory, e.g. /projects/product-launch",
+		),
+	old_string: z
+		.string()
+		.describe(
+			"Exact text to find and replace. Must be present in index.html.",
+		),
+	new_string: z.string().describe("Replacement text"),
+	replace_all: z
+		.boolean()
+		.optional()
+		.describe(
+			"Replace every occurrence instead of only the first (default: false)",
+		),
+});
+
+type Input = z.infer<typeof schema>;
+type Services = Pick<AllServices, "fs">;
+
+export const createHyperframesEditTool: ToolFactory<
+	Input,
+	Services,
+	HyperframesToolConfig
+> = (services, config): Tool<Input> => ({
+	name: TOOL_NAME,
+	description:
+		"Edit the composition HTML by replacing old_string with new_string inside index.html. Prefer this over hyperframes_write when changing a small portion of a large composition. By default only the first occurrence is replaced; set replace_all to true to replace every occurrence. Fails if old_string is not found.",
+	schema,
+	execute: async (input) => {
+		const dfs = services.fs;
+		if (!dfs) return "Error: fs service not available.";
+
+		const file = compositionFile(input.project_path, config?.rootPath);
+
+		let html: string;
+		try {
+			html = new TextDecoder().decode(await readFileBytes(dfs, file, config));
+		} catch {
+			return `Error: ${file} not found. Use hyperframes_init or hyperframes_write to create the project first.`;
+		}
+
+		const { old_string, new_string, replace_all = false } = input;
+
+		if (!html.includes(old_string)) {
+			return `Error: old_string not found in ${file}`;
+		}
+
+		const count = replace_all ? html.split(old_string).length - 1 : 1;
+		const updated = replace_all
+			? html.split(old_string).join(new_string)
+			: html.replace(old_string, new_string);
+
+		await writeFileBytes(dfs, file, updated, true, config);
+
+		return `Edited ${file}: ${count} replacement${count !== 1 ? "s" : ""} made`;
+	},
+});
+
+toolRegistry.register(TOOL_NAME, createHyperframesEditTool);
+
+declare global {
+	interface ToolTypeRegistry {
+		[TOOL_NAME]: {
+			input: Input;
+			services: Services;
+			config: HyperframesToolConfig;
+		};
+	}
+}

--- a/src/services/flows-core/tools/hyperframes/hyperframes-init.ts
+++ b/src/services/flows-core/tools/hyperframes/hyperframes-init.ts
@@ -10,69 +10,124 @@ const TOOL_NAME = "hyperframes_init" as const;
 
 // ── Templates ────────────────────────────────────────────────────────────────
 
-// 1. Neon Launch — dark purple/pink, 1920×1080, 18s, 5 scenes
-const TPL_NEON_LAUNCH = `<!doctype html>
-<html lang="en"><head>
-  <meta charset="UTF-8" /><meta name="viewport" content="width=1920, height=1080" />
+interface TailwindTemplateOptions {
+	width: number;
+	height: number;
+	duration: number;
+	durations: [number, number, number, number, number];
+	bg: string;
+	ink: string;
+	accent: string;
+	accent2: string;
+	muted: string;
+	fontDisplay: string;
+	fontData: string;
+	eyebrow: string;
+	title: string;
+	subtitle: string;
+	problem: string;
+	solution: string;
+	statLabel: string;
+	statValue: number;
+	statSuffix: string;
+	statCaption: string;
+	cta: string;
+	formatStat?: "integer" | "percent" | "decimal";
+	includeGrid?: boolean;
+	includeVignette?: boolean;
+}
+
+const sumBefore = (values: number[], index: number): number =>
+	values.slice(0, index).reduce((sum, value) => sum + value, 0);
+
+const makeTailwindTemplate = (options: TailwindTemplateOptions): string => {
+	const [d1, d2, d3, d4, d5] = options.durations;
+	const s1 = 0;
+	const s2 = sumBefore(options.durations, 1);
+	const s3 = sumBefore(options.durations, 2);
+	const s4 = sumBefore(options.durations, 3);
+	const s5 = sumBefore(options.durations, 4);
+	const transition1 = s4 - 0.25;
+	const transition2 = s5 - 0.25;
+	const sceneClass = `scene clip absolute left-0 top-0 h-[${options.height}px] w-[${options.width}px] overflow-hidden`;
+	const contentClass =
+		options.width > options.height
+			? "scene-content relative z-[1] flex h-full w-full flex-col justify-center gap-[32px] px-[160px] py-[100px]"
+			: "scene-content relative z-[1] flex h-full w-full flex-col justify-center gap-[28px] px-[80px] py-[140px]";
+	const displaySize =
+		options.width > options.height ? "text-[112px]" : "text-[132px]";
+	const supportSize = options.width > options.height ? "text-[40px]" : "text-[52px]";
+	const titleText = options.title.replace(/\n/g, "<br/>");
+	const problemText = options.problem.replace(/\n/g, "<br/>");
+	const solutionText = options.solution.replace(/\n/g, "<br/>");
+	const gridDecor = options.includeGrid
+		? '<div class="grid-bg absolute inset-0 z-[0]"></div>'
+		: "";
+	const vignetteDecor = options.includeVignette
+		? '<div class="vignette absolute inset-0 z-[49] pointer-events-none"></div>'
+		: "";
+
+	return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=${options.width}, height=${options.height}" />
   <style>
-    :root{--bg:#08080f;--ink:#f0eeff;--accent:#c840f0;--accent2:#7c6cff;--muted:#6b6880;--font-display:"Space Grotesk",sans-serif;--font-data:"JetBrains Mono",monospace}
-    *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
-    html,body{width:1920px;height:1080px;overflow:hidden;background:var(--bg);color:var(--ink)}
-    .scene{position:absolute;top:0;left:0;width:1920px;height:1080px;overflow:hidden}
-    .scene-content{width:100%;height:100%;padding:100px 160px;display:flex;flex-direction:column;justify-content:center;gap:32px;box-sizing:border-box;position:relative;z-index:1}
-    .display{font-family:var(--font-display);font-weight:900;font-size:120px;line-height:1.05;letter-spacing:-2px}
-    .sub{font-family:var(--font-display);font-weight:300;font-size:42px;line-height:1.4;color:var(--muted)}
-    .label{font-family:var(--font-data);font-size:18px;color:var(--accent);text-transform:uppercase;letter-spacing:4px}
-    .stat{font-family:var(--font-display);font-weight:900;font-size:160px;color:var(--accent2);line-height:1}
-    .grain{position:absolute;inset:0;pointer-events:none;z-index:50;opacity:0.15;background-image:radial-gradient(rgba(255,255,255,0.08) 1px,transparent 1.2px),radial-gradient(rgba(0,0,0,0.18) 1px,transparent 1.2px);background-size:3px 3px,5px 5px;background-position:0 0,1px 2px;mix-blend-mode:overlay}
-    .glow{position:absolute;border-radius:50%;filter:blur(140px);pointer-events:none;z-index:0}
+    :root{--bg:${options.bg};--ink:${options.ink};--accent:${options.accent};--accent2:${options.accent2};--muted:${options.muted};--font-display:${options.fontDisplay};--font-data:${options.fontData}}
+    *,*::before,*::after{box-sizing:border-box}
+    html,body{width:${options.width}px;height:${options.height}px;margin:0;overflow:hidden;background:var(--bg);color:var(--ink)}
+    .grain{position:absolute;inset:0;pointer-events:none;z-index:50;opacity:.15;background-image:radial-gradient(rgba(255,255,255,.08) 1px,transparent 1.2px),radial-gradient(rgba(0,0,0,.18) 1px,transparent 1.2px);background-size:3px 3px,5px 5px;background-position:0 0,1px 2px;mix-blend-mode:overlay}
+    .glow{position:absolute;border-radius:9999px;filter:blur(140px);pointer-events:none;z-index:0}
+    .grid-bg{background-image:linear-gradient(rgba(255,255,255,.055) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.055) 1px,transparent 1px);background-size:60px 60px}
+    .vignette{background:radial-gradient(ellipse at center,transparent 42%,rgba(0,0,0,.58) 100%)}
   </style>
-</head><body>
-  <div id="main" data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="18">
-    <div class="scene clip" id="s1" data-start="0" data-duration="3.5" data-track-index="0">
-      <div class="grain"></div>
-      <div class="glow" style="width:700px;height:700px;background:var(--accent);opacity:0.12;top:-200px;right:100px;"></div>
-      <div class="scene-content">
-        <p class="label" id="s1-label">INTRODUCING</p>
-        <h1 class="display" id="s1-title">Your Product<br/>Name Here</h1>
-        <p class="sub" id="s1-sub">The tagline that changes everything.</p>
+</head>
+<body>
+  <div id="main" data-composition-id="main" data-width="${options.width}" data-height="${options.height}" data-start="0" data-duration="${options.duration}" class="relative h-[${options.height}px] w-[${options.width}px] overflow-hidden bg-hf-bg text-hf-ink">
+    <div id="s1" class="${sceneClass}" data-start="${s1}" data-duration="${d1}" data-track-index="0">
+      ${gridDecor}<div class="grain"></div>
+      <div class="glow h-[620px] w-[620px] bg-hf-accent opacity-[0.12] -right-[120px] -top-[180px]"></div>
+      <div class="${contentClass}">
+        <p id="s1-label" class="font-hf-data text-[18px] uppercase tracking-[5px] text-hf-accent">${options.eyebrow}</p>
+        <h1 id="s1-title" class="font-hf-display ${displaySize} font-black leading-[1.02] text-hf-ink">${titleText}</h1>
+        <p id="s1-sub" class="max-w-[940px] font-hf-display ${supportSize} font-light leading-[1.32] text-hf-muted">${options.subtitle}</p>
       </div>
     </div>
-    <div class="scene clip" id="s2" data-start="3.5" data-duration="3.5" data-track-index="0" style="visibility:hidden;">
-      <div class="grain"></div>
-      <div class="scene-content">
-        <p class="label" id="s2-label">THE PROBLEM</p>
-        <h2 class="display" id="s2-title" style="font-size:88px">What frustrates<br/>your customers</h2>
-        <p class="sub" id="s2-sub">One sentence on the pain point.</p>
+    <div id="s2" class="${sceneClass}" data-start="${s2}" data-duration="${d2}" data-track-index="0" style="visibility:hidden;">
+      ${gridDecor}<div class="grain"></div>
+      <div class="${contentClass}">
+        <p id="s2-label" class="font-hf-data text-[18px] uppercase tracking-[5px] text-hf-accent">THE FRICTION</p>
+        <h2 id="s2-title" class="font-hf-display text-[88px] font-black leading-[1.05] text-hf-ink">${problemText}</h2>
+        <p id="s2-sub" class="max-w-[820px] font-hf-display text-[36px] font-light leading-[1.38] text-hf-muted">Name the customer pain clearly, then make the next scene feel inevitable.</p>
       </div>
     </div>
-    <div class="scene clip" id="s3" data-start="7" data-duration="3.5" data-track-index="0" style="opacity:0;">
-      <div class="grain"></div>
-      <div class="glow" style="width:900px;height:450px;background:var(--accent2);opacity:0.14;bottom:-100px;left:300px;"></div>
-      <div class="scene-content">
-        <p class="label" id="s3-label">THE SOLUTION</p>
-        <h2 class="display" id="s3-title" style="font-size:88px">Your product<br/>fixes it</h2>
-        <p class="sub" id="s3-sub">One clear sentence on how.</p>
+    <div id="s3" class="${sceneClass}" data-start="${s3}" data-duration="${d3}" data-track-index="0" style="opacity:0;">
+      ${vignetteDecor}<div class="grain"></div>
+      <div class="glow h-[520px] w-[900px] bg-hf-accent-2 opacity-[0.14] bottom-[-120px] left-[260px]"></div>
+      <div class="${contentClass}">
+        <p id="s3-label" class="font-hf-data text-[18px] uppercase tracking-[5px] text-hf-accent">THE SOLUTION</p>
+        <h2 id="s3-title" class="font-hf-display text-[92px] font-black leading-[1.04] text-hf-ink">${solutionText}</h2>
+        <p id="s3-sub" class="max-w-[900px] font-hf-display text-[36px] font-light leading-[1.38] text-hf-muted">Replace this line with the product promise or launch message.</p>
       </div>
     </div>
-    <div class="scene clip" id="s4" data-start="10.5" data-duration="4" data-track-index="0" style="opacity:0;">
-      <div class="grain"></div>
-      <div class="scene-content" style="flex-direction:row;align-items:center;gap:120px">
-        <div>
-          <p class="label" id="s4-label">TRACTION</p>
-          <div class="stat" id="s4-stat">0</div>
-          <p class="sub" style="font-size:32px">users in 30 days</p>
+    <div id="s4" class="${sceneClass}" data-start="${s4}" data-duration="${d4}" data-track-index="0" style="opacity:0;">
+      ${gridDecor}<div class="grain"></div>
+      <div class="${contentClass} flex-row items-center gap-[120px]">
+        <div class="min-w-[520px]">
+          <p id="s4-label" class="font-hf-data text-[18px] uppercase tracking-[5px] text-hf-accent">${options.statLabel}</p>
+          <div id="s4-stat" class="font-hf-display text-[160px] font-black leading-none text-hf-accent-2">0${options.statSuffix}</div>
+          <p class="font-hf-display text-[32px] font-light text-hf-muted">${options.statCaption}</p>
         </div>
-        <div style="flex:1"><p class="sub" id="s4-copy">The proof point that makes investors lean in.</p></div>
+        <p id="s4-copy" class="max-w-[760px] font-hf-display text-[42px] font-light leading-[1.28] text-hf-ink">A proof point, customer quote, or metric makes the story credible.</p>
       </div>
     </div>
-    <div class="scene clip" id="s5" data-start="14.5" data-duration="3.5" data-track-index="0" style="opacity:0;">
-      <div class="grain"></div>
-      <div class="glow" style="width:1100px;height:550px;background:var(--accent);opacity:0.09;bottom:-200px;left:50%;transform:translateX(-50%);"></div>
-      <div class="scene-content" style="align-items:center;text-align:center">
-        <p class="label" id="s5-label">GET STARTED</p>
-        <h2 class="display" id="s5-cta" style="font-size:100px">yourproduct.com</h2>
-        <p class="sub" id="s5-sub">Free to try. No credit card required.</p>
+    <div id="s5" class="${sceneClass}" data-start="${s5}" data-duration="${d5}" data-track-index="0" style="opacity:0;">
+      ${vignetteDecor}<div class="grain"></div>
+      <div class="glow h-[560px] w-[1180px] bg-hf-accent opacity-[0.1] bottom-[-220px] left-1/2 -translate-x-1/2"></div>
+      <div class="${contentClass} items-center text-center">
+        <p id="s5-label" class="font-hf-data text-[18px] uppercase tracking-[5px] text-hf-accent">GET STARTED</p>
+        <h2 id="s5-cta" class="font-hf-display text-[104px] font-black leading-[1.03] text-hf-ink">${options.cta}</h2>
+        <p id="s5-sub" class="font-hf-display text-[34px] font-light text-hf-muted">Free to try. Replace with your best next action.</p>
       </div>
     </div>
   </div>
@@ -82,423 +137,312 @@ const TPL_NEON_LAUNCH = `<!doctype html>
     var tl = gsap.timeline({ paused: true });
     tl.from("#s1-label", { y:20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 0.1);
     tl.from("#s1-title", { y:50, autoAlpha:0, duration:0.7, ease:"power4.out" }, 0.3);
-    tl.from("#s1-sub",   { y:30, autoAlpha:0, duration:0.5, ease:"power2.out" }, 0.7);
-    tl.to("#s1-title",   { y:-6, duration:1.5, ease:"sine.inOut", yoyo:true, repeat:1 }, 1.0);
-    tl.set("#s1", { autoAlpha:0 }, 3.5);
-    tl.set("#s2", { autoAlpha:1 }, 3.5);
-    tl.from("#s2-label", { x:-30, autoAlpha:0, duration:0.4, ease:"power2.out" }, 3.7);
-    tl.from("#s2-title", { y:60,  autoAlpha:0, duration:0.7, ease:"power4.out" }, 3.9);
-    tl.from("#s2-sub",   { y:30,  autoAlpha:0, duration:0.5, ease:"power2.out" }, 4.3);
-    tl.set("#s2", { autoAlpha:0 }, 7.0);
-    tl.set("#s3", { opacity:1 },   7.0);
-    tl.from("#s3-label", { x:-30, autoAlpha:0, duration:0.4, ease:"power2.out" }, 7.2);
-    tl.from("#s3-title", { y:60,  autoAlpha:0, duration:0.7, ease:"power4.out" }, 7.4);
-    tl.from("#s3-sub",   { y:30,  autoAlpha:0, duration:0.5, ease:"power2.out" }, 7.8);
-    tl.set("#s4", { opacity:1 }, 10.5);
-    tl.from("#s4-label", { x:-30, autoAlpha:0, duration:0.4, ease:"power2.out" }, 10.7);
-    var c={v:0}; tl.to(c, { v:12000, duration:2.0, ease:"power2.out", onUpdate:function(){ document.getElementById("s4-stat").textContent=c.v.toLocaleString(); }}, 11.0);
-    tl.from("#s4-copy",  { y:30,  autoAlpha:0, duration:0.5, ease:"power2.out" }, 11.3);
-    tl.set("#s5", { opacity:1 }, 14.5);
-    tl.from("#s5-label", { y:20,  autoAlpha:0, duration:0.4, ease:"power2.out" }, 14.7);
-    tl.from("#s5-cta",   { y:50,  autoAlpha:0, duration:0.7, ease:"power4.out" }, 14.9);
-    tl.from("#s5-sub",   { y:30,  autoAlpha:0, duration:0.5, ease:"power2.out" }, 15.3);
+    tl.from("#s1-sub", { y:30, autoAlpha:0, duration:0.5, ease:"power2.out" }, 0.7);
+    tl.to("#s1-title", { y:-6, duration:1.5, ease:"sine.inOut", yoyo:true, repeat:1 }, 1.0);
+    tl.set("#s1", { autoAlpha:0 }, ${s2});
+    tl.set("#s2", { autoAlpha:1 }, ${s2});
+    tl.from("#s2-label", { x:-30, autoAlpha:0, duration:0.4, ease:"power2.out" }, ${s2 + 0.2});
+    tl.from("#s2-title", { y:60, autoAlpha:0, duration:0.7, ease:"power4.out" }, ${s2 + 0.4});
+    tl.from("#s2-sub", { y:30, autoAlpha:0, duration:0.5, ease:"power2.out" }, ${s2 + 0.8});
+    tl.set("#s2", { autoAlpha:0 }, ${s3});
+    tl.set("#s3", { opacity:1 }, ${s3});
+    tl.from("#s3-label", { x:-30, autoAlpha:0, duration:0.4, ease:"power2.out" }, ${s3 + 0.2});
+    tl.from("#s3-title", { y:60, autoAlpha:0, duration:0.7, ease:"power4.out" }, ${s3 + 0.4});
+    tl.from("#s3-sub", { y:30, autoAlpha:0, duration:0.5, ease:"power2.out" }, ${s3 + 0.8});
+    tl.set("#s4", { opacity:1 }, ${s4});
+    tl.from("#s4-label", { x:-30, autoAlpha:0, duration:0.4, ease:"power2.out" }, ${s4 + 0.2});
+    var c={v:0};
+    tl.to(c, { v:${options.statValue}, duration:2.0, ease:"power2.out", onUpdate:function(){
+      var value = ${options.formatStat === "decimal" ? "c.v.toFixed(1)" : "Math.round(c.v).toLocaleString()"};
+      document.getElementById("s4-stat").textContent = value + "${options.statSuffix}";
+    }}, ${s4 + 0.5});
+    tl.from("#s4-copy", { y:30, autoAlpha:0, duration:0.5, ease:"power2.out" }, ${s4 + 0.8});
+    tl.set("#s5", { opacity:1 }, ${s5});
+    tl.from("#s5-label", { y:20, autoAlpha:0, duration:0.4, ease:"power2.out" }, ${s5 + 0.2});
+    tl.from("#s5-cta", { y:50, autoAlpha:0, duration:0.7, ease:"power4.out" }, ${s5 + 0.4});
+    tl.from("#s5-sub", { y:30, autoAlpha:0, duration:0.5, ease:"power2.out" }, ${s5 + 0.8});
     window.HyperShader.init({
-      bgColor:"#08080f", scenes:["s3","s4","s5"], timeline:tl,
-      transitions:[{time:10.25,shader:"cinematic-zoom",duration:0.5},{time:14.25,shader:"light-leak",duration:0.5}],
+      bgColor:"${options.bg}", scenes:["s3","s4","s5"], timeline:tl,
+      transitions:[{time:${transition1},shader:"cinematic-zoom",duration:0.5},{time:${transition2},shader:"light-leak",duration:0.5}],
     });
     window.__timelines["main"] = tl;
   </script>
-</body></html>`;
+</body>
+</html>`;
+};
 
-// 2. Social Reel — vertical 1080×1920, bold/punchy, 15s, 5 scenes
-const TPL_SOCIAL_REEL = `<!doctype html>
-<html lang="en"><head>
-  <meta charset="UTF-8" /><meta name="viewport" content="width=1080, height=1920" />
-  <style>
-    :root{--bg:#0d0d0d;--ink:#ffffff;--accent:#ff3c3c;--muted:#888;--font-display:"Barlow Condensed",sans-serif;--font-data:"JetBrains Mono",monospace}
-    *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
-    html,body{width:1080px;height:1920px;overflow:hidden;background:var(--bg);color:var(--ink)}
-    .scene{position:absolute;top:0;left:0;width:1080px;height:1920px;overflow:hidden}
-    .scene-content{width:100%;height:100%;padding:140px 80px;display:flex;flex-direction:column;justify-content:center;gap:28px;box-sizing:border-box;position:relative;z-index:1}
-    .display{font-family:var(--font-display);font-weight:900;font-size:140px;line-height:0.95;text-transform:uppercase;letter-spacing:-1px}
-    .sub{font-family:var(--font-display);font-weight:300;font-size:52px;line-height:1.3;color:var(--muted)}
-    .label{font-family:var(--font-data);font-size:22px;color:var(--accent);text-transform:uppercase;letter-spacing:5px}
-    .accent-bar{width:80px;height:8px;background:var(--accent);border-radius:4px}
-    .grain{position:absolute;inset:0;pointer-events:none;z-index:50;opacity:0.12;background-image:radial-gradient(rgba(255,255,255,0.08) 1px,transparent 1.2px),radial-gradient(rgba(0,0,0,0.18) 1px,transparent 1.2px);background-size:3px 3px,5px 5px;background-position:0 0,1px 2px;mix-blend-mode:overlay}
-  </style>
-</head><body>
-  <div id="main" data-composition-id="main" data-width="1080" data-height="1920" data-start="0" data-duration="15">
-    <div class="scene clip" id="s1" data-start="0" data-duration="3" data-track-index="0">
-      <div class="grain"></div>
-      <div class="scene-content">
-        <div class="accent-bar" id="s1-bar"></div>
-        <h1 class="display" id="s1-title">STOP<br/>SCROLLING</h1>
-        <p class="sub" id="s1-sub">This changes how you work.</p>
-      </div>
-    </div>
-    <div class="scene clip" id="s2" data-start="3" data-duration="2.5" data-track-index="0" style="visibility:hidden;">
-      <div class="grain"></div>
-      <div class="scene-content">
-        <p class="label" id="s2-label">THE OLD WAY</p>
-        <h2 class="display" id="s2-title" style="font-size:110px">SLOW.<br/>PAINFUL.<br/>BROKEN.</h2>
-      </div>
-    </div>
-    <div class="scene clip" id="s3" data-start="5.5" data-duration="3" data-track-index="0" style="opacity:0;">
-      <div class="grain"></div>
-      <div class="scene-content" style="background:var(--accent)">
-        <p class="label" id="s3-label" style="color:#fff">THE NEW WAY</p>
-        <h2 class="display" id="s3-title">YOUR<br/>PRODUCT<br/>NAME</h2>
-        <p class="sub" id="s3-sub" style="color:rgba(255,255,255,0.7)">One sentence. What it does.</p>
-      </div>
-    </div>
-    <div class="scene clip" id="s4" data-start="8.5" data-duration="3" data-track-index="0" style="opacity:0;">
-      <div class="grain"></div>
-      <div class="scene-content">
-        <p class="label" id="s4-label">RESULTS</p>
-        <div class="display" id="s4-stat" style="font-size:200px;color:var(--accent)">0<span style="font-size:80px">%</span></div>
-        <p class="sub" id="s4-copy">faster than anything else.</p>
-      </div>
-    </div>
-    <div class="scene clip" id="s5" data-start="11.5" data-duration="3.5" data-track-index="0" style="opacity:0;">
-      <div class="grain"></div>
-      <div class="scene-content" style="align-items:center;text-align:center">
-        <p class="label" id="s5-label">TRY IT FREE</p>
-        <h2 class="display" id="s5-cta" style="font-size:110px">LINK IN<br/>BIO</h2>
-        <div class="accent-bar" id="s5-bar" style="margin:0 auto"></div>
-      </div>
-    </div>
-  </div>
-  <script>
-    window.__timelines = window.__timelines || {};
-    if (window.lucide) window.lucide.createIcons();
-    var tl = gsap.timeline({ paused: true });
-    tl.from("#s1-bar",   { scaleX:0, transformOrigin:"left", duration:0.4, ease:"power2.out" }, 0.1);
-    tl.from("#s1-title", { y:80, autoAlpha:0, duration:0.6, ease:"power4.out" }, 0.3);
-    tl.from("#s1-sub",   { y:30, autoAlpha:0, duration:0.5, ease:"power2.out" }, 0.7);
-    tl.set("#s1", { autoAlpha:0 }, 3.0);
-    tl.set("#s2", { autoAlpha:1 }, 3.0);
-    tl.from("#s2-label", { y:20, autoAlpha:0, duration:0.3, ease:"power2.out" }, 3.2);
-    tl.from("#s2-title", { y:80, autoAlpha:0, duration:0.5, ease:"power4.out", stagger:0.12 }, 3.4);
-    tl.set("#s2", { autoAlpha:0 }, 5.5);
-    tl.set("#s3", { opacity:1 },  5.5);
-    tl.from("#s3-label", { y:20, autoAlpha:0, duration:0.3, ease:"power2.out" }, 5.7);
-    tl.from("#s3-title", { y:80, autoAlpha:0, duration:0.6, ease:"power4.out" }, 5.9);
-    tl.from("#s3-sub",   { y:30, autoAlpha:0, duration:0.4, ease:"power2.out" }, 6.3);
-    tl.set("#s4", { opacity:1 }, 8.5);
-    tl.from("#s4-label", { y:20, autoAlpha:0, duration:0.3, ease:"power2.out" }, 8.7);
-    var c={v:0}; tl.to(c, { v:87, duration:1.5, ease:"power2.out", onUpdate:function(){ document.getElementById("s4-stat").firstChild.textContent=Math.round(c.v); }}, 9.0);
-    tl.from("#s4-copy",  { y:30, autoAlpha:0, duration:0.4, ease:"power2.out" }, 9.8);
-    tl.set("#s5", { opacity:1 }, 11.5);
-    tl.from("#s5-label", { y:20, autoAlpha:0, duration:0.3, ease:"power2.out" }, 11.7);
-    tl.from("#s5-cta",   { y:60, autoAlpha:0, duration:0.6, ease:"power4.out" }, 11.9);
-    tl.from("#s5-bar",   { scaleX:0, transformOrigin:"center", duration:0.5, ease:"expo.out" }, 12.5);
-    window.HyperShader.init({
-      bgColor:"#0d0d0d", scenes:["s3","s4","s5"], timeline:tl,
-      transitions:[{time:8.25,shader:"glitch",duration:0.4},{time:11.25,shader:"cinematic-zoom",duration:0.4}],
-    });
-    window.__timelines["main"] = tl;
-  </script>
-</body></html>`;
+const TPL_NEON_LAUNCH = makeTailwindTemplate({
+	width: 1920,
+	height: 1080,
+	duration: 18,
+	durations: [3.5, 3.5, 3.5, 4, 3.5],
+	bg: "#08080f",
+	ink: "#f0eeff",
+	accent: "#c840f0",
+	accent2: "#7c6cff",
+	muted: "#8a86a4",
+	fontDisplay: '"Space Grotesk",sans-serif',
+	fontData: '"JetBrains Mono",monospace',
+	eyebrow: "INTRODUCING",
+	title: "Your Product\nName Here",
+	subtitle: "The tagline that changes everything.",
+	problem: "What frustrates\nyour customers",
+	solution: "Your product\nfixes it",
+	statLabel: "TRACTION",
+	statValue: 12000,
+	statSuffix: "",
+	statCaption: "users in 30 days",
+	cta: "yourproduct.com",
+	includeVignette: true,
+});
 
-// 3. Clean Minimal — light editorial, 1920×1080, 15s, 4 scenes
-const TPL_CLEAN_MINIMAL = `<!doctype html>
-<html lang="en"><head>
-  <meta charset="UTF-8" /><meta name="viewport" content="width=1920, height=1080" />
-  <style>
-    :root{--bg:#f7f5f0;--ink:#1a1814;--accent:#d97b2a;--muted:#8a8278;--font-display:"DM Serif Display",serif;--font-body:"DM Sans",sans-serif}
-    *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
-    html,body{width:1920px;height:1080px;overflow:hidden;background:var(--bg);color:var(--ink)}
-    .scene{position:absolute;top:0;left:0;width:1920px;height:1080px;overflow:hidden}
-    .scene-content{width:100%;height:100%;padding:120px 200px;display:flex;flex-direction:column;justify-content:center;gap:36px;box-sizing:border-box;position:relative;z-index:1}
-    .display{font-family:var(--font-display);font-weight:400;font-size:110px;line-height:1.05;color:var(--ink)}
-    .sub{font-family:var(--font-body);font-weight:300;font-size:36px;line-height:1.6;color:var(--muted);max-width:900px}
-    .label{font-family:var(--font-body);font-size:16px;color:var(--accent);text-transform:uppercase;letter-spacing:6px;font-weight:400}
-    .rule{width:60px;height:2px;background:var(--accent)}
-  </style>
-</head><body>
-  <div id="main" data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="15">
-    <div class="scene clip" id="s1" data-start="0" data-duration="4" data-track-index="0">
-      <div class="scene-content">
-        <div class="rule" id="s1-rule"></div>
-        <h1 class="display" id="s1-title">Beautiful products<br/>deserve a beautiful story.</h1>
-        <p class="sub" id="s1-sub">Replace this with your opening statement.</p>
-      </div>
-    </div>
-    <div class="scene clip" id="s2" data-start="4" data-duration="3.5" data-track-index="0" style="visibility:hidden;">
-      <div class="scene-content">
-        <p class="label" id="s2-label">WHAT WE DO</p>
-        <h2 class="display" id="s2-title" style="font-size:90px">Your core<br/>value prop.</h2>
-        <p class="sub" id="s2-sub">Describe in one or two clear sentences.</p>
-      </div>
-    </div>
-    <div class="scene clip" id="s3" data-start="7.5" data-duration="4" data-track-index="0" style="opacity:0;">
-      <div class="scene-content" style="flex-direction:row;align-items:flex-end;gap:160px">
-        <div style="flex:1">
-          <p class="label" id="s3-label">THE RESULT</p>
-          <h2 class="display" id="s3-num" style="font-size:180px;color:var(--accent)">0</h2>
-          <p class="sub" id="s3-metric" style="font-size:28px">hours saved per week</p>
-        </div>
-        <div style="flex:1.2"><p class="sub" id="s3-copy" style="font-size:40px">Supporting context that frames the number and makes it credible.</p></div>
-      </div>
-    </div>
-    <div class="scene clip" id="s4" data-start="11.5" data-duration="3.5" data-track-index="0" style="opacity:0;">
-      <div class="scene-content" style="align-items:flex-start">
-        <div class="rule" id="s4-rule"></div>
-        <h2 class="display" id="s4-cta" style="font-style:italic">Start for free today.</h2>
-        <p class="sub" id="s4-url" style="font-size:32px;color:var(--accent)">yourproduct.com</p>
-      </div>
-    </div>
-  </div>
-  <script>
-    window.__timelines = window.__timelines || {};
-    if (window.lucide) window.lucide.createIcons();
-    var tl = gsap.timeline({ paused: true });
-    tl.from("#s1-rule",  { scaleX:0, transformOrigin:"left", duration:0.5, ease:"power2.out" }, 0.2);
-    tl.from("#s1-title", { y:40, autoAlpha:0, duration:0.8, ease:"power3.out" }, 0.5);
-    tl.from("#s1-sub",   { y:20, autoAlpha:0, duration:0.6, ease:"power2.out" }, 1.0);
-    tl.set("#s1", { autoAlpha:0 }, 4.0);
-    tl.set("#s2", { autoAlpha:1 }, 4.0);
-    tl.from("#s2-label", { x:-20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 4.2);
-    tl.from("#s2-title", { y:40,  autoAlpha:0, duration:0.7, ease:"power3.out" }, 4.5);
-    tl.from("#s2-sub",   { y:20,  autoAlpha:0, duration:0.5, ease:"power2.out" }, 5.0);
-    tl.set("#s2", { autoAlpha:0 }, 7.5);
-    tl.set("#s3", { opacity:1 },  7.5);
-    tl.from("#s3-label",  { x:-20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 7.7);
-    var c={v:0}; tl.to(c, { v:40, duration:2.0, ease:"power2.out", onUpdate:function(){ document.getElementById("s3-num").textContent=Math.round(c.v); }}, 8.0);
-    tl.from("#s3-metric", { y:20,  autoAlpha:0, duration:0.5, ease:"power2.out" }, 8.3);
-    tl.from("#s3-copy",   { y:20,  autoAlpha:0, duration:0.6, ease:"power2.out" }, 8.6);
-    tl.set("#s4", { opacity:1 }, 11.5);
-    tl.from("#s4-rule",  { scaleX:0, transformOrigin:"left", duration:0.5, ease:"power2.out" }, 11.7);
-    tl.from("#s4-cta",   { y:40,  autoAlpha:0, duration:0.7, ease:"power3.out" }, 12.0);
-    tl.from("#s4-url",   { y:20,  autoAlpha:0, duration:0.5, ease:"power2.out" }, 12.5);
-    window.HyperShader.init({
-      bgColor:"#f7f5f0", scenes:["s3","s4"], timeline:tl,
-      transitions:[{time:11.25,shader:"cross-warp-morph",duration:0.5}],
-    });
-    window.__timelines["main"] = tl;
-  </script>
-</body></html>`;
+const TPL_SOCIAL_REEL = makeTailwindTemplate({
+	width: 1080,
+	height: 1920,
+	duration: 15,
+	durations: [3, 2.5, 3, 3, 3.5],
+	bg: "#0d0d0d",
+	ink: "#ffffff",
+	accent: "#ff3c3c",
+	accent2: "#ffffff",
+	muted: "#8d8d8d",
+	fontDisplay: '"Barlow Condensed",sans-serif',
+	fontData: '"JetBrains Mono",monospace',
+	eyebrow: "STOP SCROLLING",
+	title: "This changes\nhow you work",
+	subtitle: "A fast vertical draft for social launch posts.",
+	problem: "Slow.\nPainful.\nBroken.",
+	solution: "The new way\nstarts here",
+	statLabel: "RESULTS",
+	statValue: 87,
+	statSuffix: "%",
+	statCaption: "faster than the old workflow",
+	cta: "LINK IN BIO",
+});
 
-// 4. Tech Data — dark/teal, metrics-driven with D3 bars, 1920×1080, 20s, 5 scenes
-const TPL_TECH_DATA = `<!doctype html>
-<html lang="en"><head>
-  <meta charset="UTF-8" /><meta name="viewport" content="width=1920, height=1080" />
-  <style>
-    :root{--bg:#040d0f;--ink:#e8f8f5;--accent:#00e5c0;--accent2:#0066ff;--muted:#3d6b64;--font-display:"Space Grotesk",sans-serif;--font-data:"JetBrains Mono",monospace}
-    *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
-    html,body{width:1920px;height:1080px;overflow:hidden;background:var(--bg);color:var(--ink)}
-    .scene{position:absolute;top:0;left:0;width:1920px;height:1080px;overflow:hidden}
-    .scene-content{width:100%;height:100%;padding:80px 140px;display:flex;flex-direction:column;justify-content:center;gap:28px;box-sizing:border-box;position:relative;z-index:1}
-    .display{font-family:var(--font-display);font-weight:900;font-size:100px;line-height:1.05}
-    .sub{font-family:var(--font-display);font-weight:300;font-size:36px;line-height:1.4;color:var(--muted)}
-    .label{font-family:var(--font-data);font-size:16px;color:var(--accent);text-transform:uppercase;letter-spacing:4px}
-    .mono{font-family:var(--font-data);font-size:28px;color:var(--accent)}
-    .stat-big{font-family:var(--font-data);font-weight:700;font-size:140px;color:var(--accent);line-height:1}
-    .grid-bg{position:absolute;inset:0;background-image:linear-gradient(rgba(0,229,192,0.04) 1px,transparent 1px),linear-gradient(90deg,rgba(0,229,192,0.04) 1px,transparent 1px);background-size:60px 60px;pointer-events:none;z-index:0}
-    .grain{position:absolute;inset:0;pointer-events:none;z-index:50;opacity:0.12;background-image:radial-gradient(rgba(255,255,255,0.08) 1px,transparent 1.2px),radial-gradient(rgba(0,0,0,0.18) 1px,transparent 1.2px);background-size:3px 3px,5px 5px;background-position:0 0,1px 2px;mix-blend-mode:overlay}
-  </style>
-</head><body>
-  <div id="main" data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="20">
-    <div class="scene clip" id="s1" data-start="0" data-duration="4" data-track-index="0">
-      <div class="grid-bg"></div><div class="grain"></div>
-      <div class="scene-content">
-        <p class="label" id="s1-label">// PRODUCT.LAUNCH</p>
-        <h1 class="display" id="s1-title">Built for teams<br/>who ship fast.</h1>
-        <p class="sub" id="s1-sub">Your product description in one line.</p>
-        <p class="mono" id="s1-mono">v2.0.0 — now available</p>
-      </div>
-    </div>
-    <div class="scene clip" id="s2" data-start="4" data-duration="4" data-track-index="0" style="visibility:hidden;">
-      <div class="grid-bg"></div><div class="grain"></div>
-      <div class="scene-content" style="flex-direction:row;align-items:center;gap:100px">
-        <div style="flex:1">
-          <p class="label" id="s2-label">PERFORMANCE</p>
-          <div class="stat-big" id="s2-stat">0<span style="font-size:60px">ms</span></div>
-          <p class="sub" id="s2-sub">average response time</p>
-        </div>
-        <div style="flex:1">
-          <svg id="s2-chart" width="700" height="320" viewBox="0 0 700 320"></svg>
-        </div>
-      </div>
-    </div>
-    <div class="scene clip" id="s3" data-start="8" data-duration="4" data-track-index="0" style="opacity:0;">
-      <div class="grid-bg"></div><div class="grain"></div>
-      <div class="scene-content">
-        <p class="label" id="s3-label">KEY FEATURES</p>
-        <div style="display:flex;gap:60px;margin-top:20px">
-          <div id="s3-f1"><i data-lucide="zap" style="width:48px;height:48px;color:var(--accent);stroke-width:2"></i><h3 style="font-family:var(--font-display);font-size:42px;font-weight:700;margin-top:16px">Feature One</h3><p class="sub" style="font-size:28px;margin-top:8px">Short benefit.</p></div>
-          <div id="s3-f2"><i data-lucide="shield-check" style="width:48px;height:48px;color:var(--accent);stroke-width:2"></i><h3 style="font-family:var(--font-display);font-size:42px;font-weight:700;margin-top:16px">Feature Two</h3><p class="sub" style="font-size:28px;margin-top:8px">Short benefit.</p></div>
-          <div id="s3-f3"><i data-lucide="chart-no-axes-combined" style="width:48px;height:48px;color:var(--accent);stroke-width:2"></i><h3 style="font-family:var(--font-display);font-size:42px;font-weight:700;margin-top:16px">Feature Three</h3><p class="sub" style="font-size:28px;margin-top:8px">Short benefit.</p></div>
-        </div>
-      </div>
-    </div>
-    <div class="scene clip" id="s4" data-start="12" data-duration="4" data-track-index="0" style="opacity:0;">
-      <div class="grid-bg"></div><div class="grain"></div>
-      <div class="scene-content" style="flex-direction:row;gap:120px;align-items:center">
-        <div style="flex:1"><p class="label" id="s4-label">USED BY</p><div class="stat-big" id="s4-stat2">0</div><p class="sub">teams worldwide</p></div>
-        <div style="flex:1.5"><p class="sub" id="s4-quote" style="font-size:42px;font-style:italic;color:var(--ink)">"Replace with a real customer quote that validates your product."</p><p class="mono" style="font-size:22px;margin-top:24px">— Customer Name, Role</p></div>
-      </div>
-    </div>
-    <div class="scene clip" id="s5" data-start="16" data-duration="4" data-track-index="0" style="opacity:0;">
-      <div class="grid-bg"></div><div class="grain"></div>
-      <div class="scene-content" style="align-items:center;text-align:center">
-        <p class="label" id="s5-label">// START.FREE</p>
-        <h2 class="display" id="s5-cta" style="font-size:120px">yourproduct.com</h2>
-        <p class="sub" id="s5-sub">14-day free trial. No card required.</p>
-      </div>
-    </div>
-  </div>
-  <script>
-    window.__timelines = window.__timelines || {};
-    if (window.lucide) window.lucide.createIcons();
-    var bars=[55,80,65,95,75,100,88]; var svg=d3.select("#s2-chart");
-    svg.selectAll("rect").data(bars).join("rect").attr("x",function(d,i){return i*90+20}).attr("y",function(d){return 280-d*2.6}).attr("width",60).attr("height",function(d){return d*2.6}).attr("rx",6).attr("fill","var(--accent)").attr("opacity",0.85);
-    var tl = gsap.timeline({ paused: true });
-    tl.from("#s1-label", { y:20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 0.1);
-    tl.from("#s1-title", { y:50, autoAlpha:0, duration:0.7, ease:"power4.out" }, 0.3);
-    tl.from("#s1-sub",   { y:30, autoAlpha:0, duration:0.5, ease:"power2.out" }, 0.7);
-    tl.from("#s1-mono",  { y:20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 1.0);
-    tl.set("#s1", { autoAlpha:0 }, 4.0);
-    tl.set("#s2", { autoAlpha:1 }, 4.0);
-    tl.from("#s2-label", { x:-20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 4.2);
-    var c1={v:0}; tl.to(c1, { v:12, duration:1.5, ease:"power2.out", onUpdate:function(){ document.getElementById("s2-stat").firstChild.textContent=Math.round(c1.v); }}, 4.5);
-    tl.from("#s2-sub",   { y:20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 4.8);
-    tl.from("#s2-chart rect", { scaleY:0, transformOrigin:"bottom", duration:0.6, ease:"expo.out", stagger:0.08 }, 5.0);
-    tl.set("#s2", { autoAlpha:0 }, 8.0);
-    tl.set("#s3", { opacity:1 },  8.0);
-    tl.from("#s3-label", { x:-20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 8.2);
-    tl.from("#s3-f1",    { y:40,  autoAlpha:0, duration:0.5, ease:"power3.out" }, 8.5);
-    tl.from("#s3-f2",    { y:40,  autoAlpha:0, duration:0.5, ease:"power3.out" }, 8.7);
-    tl.from("#s3-f3",    { y:40,  autoAlpha:0, duration:0.5, ease:"power3.out" }, 8.9);
-    tl.set("#s4", { opacity:1 }, 12.0);
-    tl.from("#s4-label", { x:-20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 12.2);
-    var c2={v:0}; tl.to(c2, { v:4200, duration:2.0, ease:"power2.out", onUpdate:function(){ document.getElementById("s4-stat2").textContent=c2.v.toLocaleString(); }}, 12.5);
-    tl.from("#s4-quote",  { y:30, autoAlpha:0, duration:0.6, ease:"power2.out" }, 13.0);
-    tl.set("#s5", { opacity:1 }, 16.0);
-    tl.from("#s5-label", { y:20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 16.2);
-    tl.from("#s5-cta",   { y:50, autoAlpha:0, duration:0.7, ease:"power4.out" }, 16.4);
-    tl.from("#s5-sub",   { y:30, autoAlpha:0, duration:0.5, ease:"power2.out" }, 16.8);
-    window.HyperShader.init({
-      bgColor:"#040d0f", scenes:["s3","s4","s5"], timeline:tl,
-      transitions:[{time:11.75,shader:"cinematic-zoom",duration:0.5},{time:15.75,shader:"chromatic-split",duration:0.4}],
-    });
-    window.__timelines["main"] = tl;
-  </script>
-</body></html>`;
+const TPL_CLEAN_MINIMAL = makeTailwindTemplate({
+	width: 1920,
+	height: 1080,
+	duration: 15,
+	durations: [3.5, 3, 3, 3, 2.5],
+	bg: "#f7f5f0",
+	ink: "#1a1814",
+	accent: "#d97b2a",
+	accent2: "#1a1814",
+	muted: "#8a8278",
+	fontDisplay: '"DM Serif Display",serif',
+	fontData: '"Space Grotesk",sans-serif',
+	eyebrow: "EDITORIAL STORY",
+	title: "Beautiful products\ndeserve a story",
+	subtitle: "A restrained template for premium announcements.",
+	problem: "Too much noise\nnot enough clarity",
+	solution: "A cleaner way\nto explain value",
+	statLabel: "THE RESULT",
+	statValue: 40,
+	statSuffix: "",
+	statCaption: "hours saved per week",
+	cta: "Start for free today.",
+});
 
-// 5. Warm Cinema — amber/gold tones, storytelling, 1920×1080, 18s, 5 scenes
-const TPL_WARM_CINEMA = `<!doctype html>
-<html lang="en"><head>
-  <meta charset="UTF-8" /><meta name="viewport" content="width=1920, height=1080" />
-  <style>
-    :root{--bg:#100c07;--ink:#f5ead6;--accent:#c9892a;--accent2:#e8b86d;--muted:#7a6a52;--font-display:"Cormorant",serif;--font-body:"Space Grotesk",sans-serif}
-    *,*::before,*::after{margin:0;padding:0;box-sizing:border-box}
-    html,body{width:1920px;height:1080px;overflow:hidden;background:var(--bg);color:var(--ink)}
-    .scene{position:absolute;top:0;left:0;width:1920px;height:1080px;overflow:hidden}
-    .scene-content{width:100%;height:100%;padding:120px 200px;display:flex;flex-direction:column;justify-content:center;gap:28px;box-sizing:border-box;position:relative;z-index:1}
-    .display{font-family:var(--font-display);font-weight:600;font-size:120px;line-height:1.05}
-    .italic{font-style:italic;font-weight:300}
-    .sub{font-family:var(--font-body);font-weight:400;font-size:32px;line-height:1.6;color:var(--muted);max-width:880px}
-    .label{font-family:var(--font-body);font-size:15px;color:var(--accent);text-transform:uppercase;letter-spacing:6px}
-    .divider{width:100px;height:1px;background:var(--accent);opacity:0.6}
-    .warm-glow{position:absolute;border-radius:50%;filter:blur(180px);pointer-events:none;z-index:0}
-    .vignette{position:absolute;inset:0;pointer-events:none;z-index:49;background:radial-gradient(ellipse at center,transparent 40%,rgba(0,0,0,0.6) 100%)}
-    .grain{position:absolute;inset:0;pointer-events:none;z-index:50;opacity:0.18;background-image:radial-gradient(rgba(255,255,255,0.08) 1px,transparent 1.2px),radial-gradient(rgba(0,0,0,0.18) 1px,transparent 1.2px);background-size:3px 3px,5px 5px;background-position:0 0,1px 2px;mix-blend-mode:overlay}
-  </style>
-</head><body>
-  <div id="main" data-composition-id="main" data-width="1920" data-height="1080" data-start="0" data-duration="18">
-    <div class="scene clip" id="s1" data-start="0" data-duration="4" data-track-index="0">
-      <div class="warm-glow" style="width:800px;height:400px;background:var(--accent);opacity:0.08;bottom:-100px;right:-100px;"></div>
-      <div class="vignette"></div><div class="grain"></div>
-      <div class="scene-content">
-        <p class="label" id="s1-label">EST. 2024</p>
-        <div class="divider" id="s1-div"></div>
-        <h1 class="display italic" id="s1-title">Every great product<br/>begins with a story.</h1>
-      </div>
+const TPL_TECH_DATA = makeTailwindTemplate({
+	width: 1920,
+	height: 1080,
+	duration: 20,
+	durations: [4, 4, 4, 4, 4],
+	bg: "#040d0f",
+	ink: "#e8f8f5",
+	accent: "#00e5c0",
+	accent2: "#0066ff",
+	muted: "#5b807b",
+	fontDisplay: '"Space Grotesk",sans-serif',
+	fontData: '"JetBrains Mono",monospace',
+	eyebrow: "// PRODUCT.LAUNCH",
+	title: "Built for teams\nwho ship fast",
+	subtitle: "A metrics-forward launch draft with technical energy.",
+	problem: "Latency hides\ninside every workflow",
+	solution: "Ship decisions\nat product speed",
+	statLabel: "PERFORMANCE",
+	statValue: 12,
+	statSuffix: "ms",
+	statCaption: "average response time",
+	cta: "yourproduct.com",
+	includeGrid: true,
+});
+
+const TPL_WARM_CINEMA = makeTailwindTemplate({
+	width: 1920,
+	height: 1080,
+	duration: 18,
+	durations: [4, 3.5, 3.5, 3.5, 3.5],
+	bg: "#100c07",
+	ink: "#f5ead6",
+	accent: "#c9892a",
+	accent2: "#e8b86d",
+	muted: "#9a8460",
+	fontDisplay: '"Cormorant",serif',
+	fontData: '"Space Grotesk",sans-serif',
+	eyebrow: "EST. 2024",
+	title: "Every great product\nbegins with a story",
+	subtitle: "A warm cinematic structure for founder-led launches.",
+	problem: "What if it was\njust easier?",
+	solution: "Introducing\nProduct Name",
+	statLabel: "IN NUMBERS",
+	statValue: 4.9,
+	statSuffix: "/5",
+	statCaption: "average customer rating",
+	cta: "Begin your story.",
+	formatStat: "decimal",
+	includeVignette: true,
+});
+
+// ── Scaffold templates ────────────────────────────────────────────────────────
+
+interface ScaffoldOptions {
+	width: number;
+	height: number;
+	durations: number[];
+	fills: string[];
+	shaderGroups: Array<{ indices: [number, number]; shader: string }>;
+}
+
+const makeScaffoldHTML = ({
+	width,
+	height,
+	durations,
+	fills,
+	shaderGroups,
+}: ScaffoldOptions): string => {
+	let t = 0;
+	const starts = durations.map((d) => {
+		const s = t;
+		t += d;
+		return s;
+	});
+	const total = t;
+
+	const firstAnchors = new Set(shaderGroups.map((g) => g.indices[0]));
+	const secondAnchors = new Set(shaderGroups.map((g) => g.indices[1]));
+	const pad = height > width ? "120px 80px" : "80px 160px";
+
+	const scenesHtml = durations
+		.map((d, i) => {
+			const id = `s${i + 1}`;
+			const style =
+				i === 0
+					? ""
+					: firstAnchors.has(i) || secondAnchors.has(i)
+						? ` style="opacity:0;"`
+						: ` style="visibility:hidden;"`;
+			return `      <div class="scene clip" id="${id}" data-start="${starts[i]}" data-duration="${d}" data-track-index="0"${style}>\n        <div class="grain"></div><div class="scene-content"><!-- FILL: ${fills[i] ?? `scene ${i + 1}`} --></div>\n      </div>`;
+		})
+		.join("\n");
+
+	const js: string[] = [
+		"      window.__timelines = window.__timelines || {};",
+		"      if (window.lucide) window.lucide.createIcons();",
+		"      var tl = gsap.timeline({ paused: true });",
+		`      tl.set("#s1", { autoAlpha:0 }, ${starts[1]});`,
+	];
+
+	for (let i = 1; i < durations.length; i++) {
+		const id = `#s${i + 1}`;
+		const isLast = i === durations.length - 1;
+		if (firstAnchors.has(i)) {
+			js.push(
+				`      tl.set("${id}", { opacity:1 }, ${starts[i]}); // first anchor`,
+			);
+		} else if (!secondAnchors.has(i)) {
+			if (isLast) {
+				js.push(`      tl.set("${id}", { autoAlpha:1 }, ${starts[i]});`);
+			} else {
+				js.push(
+					`      tl.set("${id}", { autoAlpha:1 }, ${starts[i]}); tl.set("${id}", { autoAlpha:0 }, ${starts[i] + durations[i]});`,
+				);
+			}
+		}
+		// second anchors: HyperShader handles visibility — no explicit toggle needed
+	}
+
+	js.push("      // === FILL: scene animations ===");
+
+	for (const g of shaderGroups) {
+		const [a, b] = g.indices;
+		const transTime = +(starts[b] - 0.25).toFixed(2);
+		js.push(
+			`      window.HyperShader.init({ bgColor: getComputedStyle(document.documentElement).getPropertyValue("--bg").trim() || "#0a0a0d", scenes: ["s${a + 1}", "s${b + 1}"], timeline: tl, transitions: [{ time: ${transTime}, shader: "${g.shader}", duration: 0.5 }] });`,
+		);
+	}
+
+	js.push('      window.__timelines["main"] = tl;');
+
+	return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=${width}, height=${height}" />
+    <style>
+      :root { --bg:#0a0a0d; --ink:#f5f5f7; --accent:#7c6cff; --muted:#5a6270; --accent-dim:#3d3680; --font-display:"Space Grotesk",sans-serif; --font-data:"JetBrains Mono",monospace; }
+      *,*::before,*::after { margin:0; padding:0; box-sizing:border-box }
+      html,body { width:${width}px; height:${height}px; overflow:hidden; background:var(--bg); color:var(--ink) }
+      .scene { position:absolute; top:0; left:0; width:${width}px; height:${height}px; overflow:hidden }
+      .scene-content { width:100%; height:100%; padding:${pad}; display:flex; flex-direction:column; justify-content:center; gap:24px; box-sizing:border-box; position:relative; z-index:1 }
+      .grain { position:absolute; inset:0; pointer-events:none; z-index:50; opacity:0.18; background-image:radial-gradient(rgba(255,255,255,0.08) 1px,transparent 1.2px),radial-gradient(rgba(0,0,0,0.18) 1px,transparent 1.2px); background-size:3px 3px,5px 5px; background-position:0 0,1px 2px; mix-blend-mode:overlay }
+    </style>
+  </head>
+  <body>
+    <div id="main" data-composition-id="main" data-width="${width}" data-height="${height}" data-start="0" data-duration="${total}">
+${scenesHtml}
     </div>
-    <div class="scene clip" id="s2" data-start="4" data-duration="3.5" data-track-index="0" style="visibility:hidden;">
-      <div class="warm-glow" style="width:600px;height:600px;background:var(--accent2);opacity:0.06;top:-200px;left:200px;"></div>
-      <div class="vignette"></div><div class="grain"></div>
-      <div class="scene-content">
-        <p class="label" id="s2-label">THE VISION</p>
-        <h2 class="display" id="s2-title" style="font-size:90px">What if it was<br/><span class="italic">just easier?</span></h2>
-        <p class="sub" id="s2-sub">Replace with your mission or founding insight.</p>
-      </div>
-    </div>
-    <div class="scene clip" id="s3" data-start="7.5" data-duration="3.5" data-track-index="0" style="opacity:0;">
-      <div class="warm-glow" style="width:900px;height:450px;background:var(--accent);opacity:0.1;bottom:-150px;left:50%;transform:translateX(-50%);"></div>
-      <div class="vignette"></div><div class="grain"></div>
-      <div class="scene-content" style="align-items:center;text-align:center">
-        <p class="label" id="s3-label">INTRODUCING</p>
-        <h2 class="display" id="s3-title" style="font-size:160px">Product<br/>Name</h2>
-        <p class="sub" id="s3-sub" style="text-align:center;margin:0 auto">Your tagline in one beautiful sentence.</p>
-      </div>
-    </div>
-    <div class="scene clip" id="s4" data-start="11" data-duration="3.5" data-track-index="0" style="opacity:0;">
-      <div class="vignette"></div><div class="grain"></div>
-      <div class="scene-content" style="flex-direction:row;align-items:center;gap:160px">
-        <div style="flex:1">
-          <p class="label" id="s4-label">IN NUMBERS</p>
-          <h3 class="display" id="s4-n1" style="font-size:100px;color:var(--accent2)">0K+</h3>
-          <p class="sub" style="font-size:26px">happy customers</p>
-        </div>
-        <div style="flex:1">
-          <h3 class="display" id="s4-n2" style="font-size:100px;color:var(--accent2)">0★</h3>
-          <p class="sub" style="font-size:26px">average rating</p>
-        </div>
-        <div style="flex:1">
-          <h3 class="display" id="s4-n3" style="font-size:100px;color:var(--accent2)">0x</h3>
-          <p class="sub" style="font-size:26px">faster results</p>
-        </div>
-      </div>
-    </div>
-    <div class="scene clip" id="s5" data-start="14.5" data-duration="3.5" data-track-index="0" style="opacity:0;">
-      <div class="warm-glow" style="width:1200px;height:600px;background:var(--accent);opacity:0.07;bottom:-200px;left:50%;transform:translateX(-50%);"></div>
-      <div class="vignette"></div><div class="grain"></div>
-      <div class="scene-content" style="align-items:center;text-align:center">
-        <div class="divider" id="s5-div" style="margin:0 auto"></div>
-        <h2 class="display italic" id="s5-cta" style="font-size:100px">Begin your story.</h2>
-        <p class="sub" id="s5-url" style="color:var(--accent2);text-align:center">yourproduct.com</p>
-      </div>
-    </div>
-  </div>
-  <script>
-    window.__timelines = window.__timelines || {};
-    if (window.lucide) window.lucide.createIcons();
-    var tl = gsap.timeline({ paused: true });
-    tl.from("#s1-label", { y:20, autoAlpha:0, duration:0.5, ease:"power2.out" }, 0.2);
-    tl.from("#s1-div",   { scaleX:0, transformOrigin:"left", duration:0.6, ease:"power2.out" }, 0.5);
-    tl.from("#s1-title", { y:40, autoAlpha:0, duration:1.0, ease:"power3.out" }, 0.7);
-    tl.to("#s1-title",   { y:-5, duration:2.0, ease:"sine.inOut", yoyo:true, repeat:1 }, 1.5);
-    tl.set("#s1", { autoAlpha:0 }, 4.0);
-    tl.set("#s2", { autoAlpha:1 }, 4.0);
-    tl.from("#s2-label", { y:20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 4.2);
-    tl.from("#s2-title", { y:40, autoAlpha:0, duration:0.8, ease:"power3.out" }, 4.5);
-    tl.from("#s2-sub",   { y:20, autoAlpha:0, duration:0.6, ease:"power2.out" }, 5.0);
-    tl.set("#s2", { autoAlpha:0 }, 7.5);
-    tl.set("#s3", { opacity:1 },  7.5);
-    tl.from("#s3-label", { y:20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 7.7);
-    tl.from("#s3-title", { scale:0.92, autoAlpha:0, duration:1.0, ease:"power3.out" }, 7.9);
-    tl.from("#s3-sub",   { y:20, autoAlpha:0, duration:0.6, ease:"power2.out" }, 8.6);
-    tl.set("#s4", { opacity:1 }, 11.0);
-    tl.from("#s4-label", { y:20, autoAlpha:0, duration:0.4, ease:"power2.out" }, 11.2);
-    tl.from("#s4-n1",    { y:40, autoAlpha:0, duration:0.6, ease:"power3.out" }, 11.4);
-    tl.from("#s4-n2",    { y:40, autoAlpha:0, duration:0.6, ease:"power3.out" }, 11.6);
-    tl.from("#s4-n3",    { y:40, autoAlpha:0, duration:0.6, ease:"power3.out" }, 11.8);
-    var c1={v:0}; tl.to(c1, {v:50,duration:1.5,ease:"power2.out",onUpdate:function(){document.getElementById("s4-n1").textContent=Math.round(c1.v)+"K+";}},11.5);
-    var c2={v:0}; tl.to(c2, {v:4.9,duration:1.5,ease:"power2.out",onUpdate:function(){document.getElementById("s4-n2").textContent=c2.v.toFixed(1)+"★";}},11.7);
-    var c3={v:0}; tl.to(c3, {v:10,duration:1.5,ease:"power2.out",onUpdate:function(){document.getElementById("s4-n3").textContent=Math.round(c3.v)+"x";}},11.9);
-    tl.set("#s5", { opacity:1 }, 14.5);
-    tl.from("#s5-div",  { scaleX:0, transformOrigin:"center", duration:0.5, ease:"power2.out" }, 14.7);
-    tl.from("#s5-cta",  { y:40,  autoAlpha:0, duration:0.8, ease:"power3.out" }, 15.0);
-    tl.from("#s5-url",  { y:20,  autoAlpha:0, duration:0.6, ease:"power2.out" }, 15.5);
-    window.HyperShader.init({
-      bgColor:"#100c07", scenes:["s3","s4","s5"], timeline:tl,
-      transitions:[{time:11.0,shader:"thermal-distortion",duration:0.5},{time:14.25,shader:"light-leak",duration:0.5}],
-    });
-    window.__timelines["main"] = tl;
-  </script>
-</body></html>`;
+    <script>
+${js.join("\n")}
+    </script>
+  </body>
+</html>`;
+};
+
+const SCAFFOLD_SOCIAL_REEL = makeScaffoldHTML({
+	width: 1080,
+	height: 1920,
+	durations: [2.5, 2.5, 2.5, 2.5, 2.5, 2.5],
+	fills: ["hook", "context", "build-up", "hero", "proof", "CTA"],
+	shaderGroups: [{ indices: [2, 3], shader: "cinematic-zoom" }],
+});
+
+const SCAFFOLD_LAUNCH_TEASER = makeScaffoldHTML({
+	width: 1920,
+	height: 1080,
+	durations: [3, 3, 3, 3.5, 3, 3, 3, 3.5],
+	fills: ["hook", "context", "problem", "pivot", "solution", "proof", "momentum", "CTA"],
+	shaderGroups: [
+		{ indices: [3, 4], shader: "cinematic-zoom" },
+		{ indices: [6, 7], shader: "light-leak" },
+	],
+});
+
+const SCAFFOLD_EXPLAINER = makeScaffoldHTML({
+	width: 1920,
+	height: 1080,
+	durations: [3, 3, 4, 3.5, 4, 5, 3.5, 4, 3.5, 4, 4, 3.5],
+	fills: [
+		"hook", "context", "problem-1", "problem-2", "pivot",
+		"solution-1", "solution-2", "proof-1", "proof-2", "momentum", "vision", "CTA",
+	],
+	shaderGroups: [
+		{ indices: [2, 3], shader: "cinematic-zoom" },
+		{ indices: [8, 9], shader: "domain-warp" },
+	],
+});
+
+const SCAFFOLD_CINEMATIC = makeScaffoldHTML({
+	width: 1920,
+	height: 1080,
+	durations: [8, 7, 8, 10, 9, 10, 8],
+	fills: ["title", "world", "tension", "revelation", "transformation", "consequence", "resolve"],
+	shaderGroups: [
+		{ indices: [2, 3], shader: "cross-warp-morph" },
+		{ indices: [5, 6], shader: "thermal-distortion" },
+	],
+});
 
 // ── Template registry ─────────────────────────────────────────────────────────
 
@@ -512,34 +456,57 @@ interface TemplateEntry {
 const TEMPLATES: TemplateEntry[] = [
 	{
 		name: "Neon Launch",
-		description: "Dark purple/pink, 1920×1080, 18s — dramatic product launch",
+		description: "Dark purple/pink, 1920x1080, 18s - dramatic product launch",
 		filename: "neon-launch.html",
 		html: TPL_NEON_LAUNCH,
 	},
 	{
 		name: "Social Reel",
-		description: "Bold vertical, 1080×1920, 15s — punchy social promo",
+		description: "Bold vertical, 1080x1920, 15s - punchy social promo",
 		filename: "social-reel.html",
 		html: TPL_SOCIAL_REEL,
 	},
 	{
 		name: "Clean Minimal",
-		description: "Light editorial, 1920×1080, 15s — serif typography-forward",
+		description: "Light editorial, 1920x1080, 15s - typography-forward",
 		filename: "clean-minimal.html",
 		html: TPL_CLEAN_MINIMAL,
 	},
 	{
 		name: "Tech Data",
-		description:
-			"Dark/teal, 1920×1080, 20s — metrics and D3 chart visualisation",
+		description: "Dark/teal, 1920x1080, 20s - metrics and product proof",
 		filename: "tech-data.html",
 		html: TPL_TECH_DATA,
 	},
 	{
 		name: "Warm Cinema",
-		description: "Amber/gold, 1920×1080, 18s — cinematic storytelling",
+		description: "Amber/gold, 1920x1080, 18s - cinematic storytelling",
 		filename: "warm-cinema.html",
 		html: TPL_WARM_CINEMA,
+	},
+	{
+		name: "Scaffold Social Reel",
+		description: "Structural scaffold: 1080x1920, 15s, 6 scenes, 1 shader group",
+		filename: "scaffold-social-reel.html",
+		html: SCAFFOLD_SOCIAL_REEL,
+	},
+	{
+		name: "Scaffold Launch Teaser",
+		description: "Structural scaffold: 1920x1080, 25s, 8 scenes, 2 shader groups",
+		filename: "scaffold-launch-teaser.html",
+		html: SCAFFOLD_LAUNCH_TEASER,
+	},
+	{
+		name: "Scaffold Explainer",
+		description: "Structural scaffold: 1920x1080, 45s, 12 scenes, 2 shader groups",
+		filename: "scaffold-explainer.html",
+		html: SCAFFOLD_EXPLAINER,
+	},
+	{
+		name: "Scaffold Cinematic",
+		description: "Structural scaffold: 1920x1080, 60s, 7 scenes, 2 shader groups, long durations",
+		filename: "scaffold-cinematic.html",
+		html: SCAFFOLD_CINEMATIC,
 	},
 ];
 
@@ -577,7 +544,7 @@ export const createHyperframesInitTool: ToolFactory<
 	HyperframesToolConfig
 > = (services, config): Tool<Input> => ({
 	name: TOOL_NAME,
-	description: `Initialise a new HyperFrames project. Writes index.html using the chosen template and creates templates/ with all 5 ready-made video promo designs. Available templates: ${TEMPLATES.map((t) => `${t.filename.replace(".html", "")} (${t.description})`).join(" | ")}. Use force: true to overwrite an existing project.`,
+	description: `Initialise a new HyperFrames project. Writes index.html using the chosen Tailwind-first template. Available templates: ${TEMPLATES.map((t) => `${t.filename.replace(".html", "")} (${t.description})`).join(" | ")}. Use force: true to overwrite an existing project.`,
 	schema,
 	execute: async (input) => {
 		const dfs = services.fs;
@@ -590,7 +557,7 @@ export const createHyperframesInitTool: ToolFactory<
 				await readFileBytes(dfs, indexFile, config);
 				return `Error: ${indexFile} already exists. Use force: true to overwrite.`;
 			} catch {
-				// Does not exist — proceed
+				// Does not exist - proceed
 			}
 		}
 
@@ -600,7 +567,7 @@ export const createHyperframesInitTool: ToolFactory<
 
 		await writeFileBytes(dfs, indexFile, chosen.html, true, config);
 
-		return `Initialised: ${indexFile} with template "${chosen.name}" (${chosen.description}). Edit with hyperframes_write, then hyperframes_validate and hyperframes_show.`;
+		return `Initialised: ${indexFile} with Tailwind template "${chosen.name}" (${chosen.description}). Edit with hyperframes_write, then hyperframes_validate and hyperframes_show.`;
 	},
 });
 

--- a/src/services/flows-core/tools/hyperframes/hyperframes-remote-asset-import.ts
+++ b/src/services/flows-core/tools/hyperframes/hyperframes-remote-asset-import.ts
@@ -6,6 +6,7 @@ import { writeFileBytes } from "flow-core/tools/fs/util";
 import {
 	createDefaultWebErrorResult,
 	createWebResult,
+	requireWebBrowserService,
 } from "flow-core/tools/web/web-tool-utils";
 import {
 	downloadResourceBytes,
@@ -15,6 +16,8 @@ import { normalizeProjectPath } from "flow-core/tools/hyperframes/util";
 import type { HyperframesToolConfig } from "flow-core/tools/hyperframes/config";
 
 const TOOL_NAME = "hyperframes_remote_asset_import" as const;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_HTML_CHARS = 240_000;
 
 const schema = z.object({
 	project_path: z
@@ -68,7 +71,118 @@ const normalizeResourceAssetPath = (
 		.join("/");
 };
 
-type Services = Pick<AllServices, "fs">;
+const resolveUrl = (value: string | null | undefined, baseUrl: string): string | null => {
+	if (!value) return null;
+	if (value.startsWith("data:") || value.startsWith("blob:")) return null;
+	try {
+		return new URL(value, baseUrl).toString();
+	} catch {
+		return null;
+	}
+};
+
+const attrFromHtml = (html: string, attr: string): string | undefined => {
+	const match = new RegExp(`\\b${attr}=([\"'])(.*?)\\1`, "i").exec(html);
+	return match
+		? match[2]
+				.replace(/&amp;/g, "&")
+				.replace(/&quot;/g, '"')
+				.replace(/&#39;/g, "'")
+		: undefined;
+};
+
+const isGoogleImgresUrl = (url: string): boolean => {
+	try {
+		const parsed = new URL(url);
+		return (
+			parsed.pathname === "/imgres" &&
+			(parsed.hostname === "www.google.com" ||
+				parsed.hostname.endsWith(".google.com"))
+		);
+	} catch {
+		return false;
+	}
+};
+
+const fallbackImageUrlFromGoogleImgres = (url: string): string | null => {
+	try {
+		const parsed = new URL(url);
+		return parsed.searchParams.get("imgurl");
+	} catch {
+		return null;
+	}
+};
+
+const isUsableGoogleResolvedImageUrl = (url: string): boolean => {
+	if (url.startsWith("data:") || url.startsWith("blob:")) return false;
+	try {
+		const parsed = new URL(url);
+		const host = parsed.hostname.toLowerCase();
+		if (host.startsWith("encrypted-tbn") && host.endsWith("gstatic.com")) {
+			return false;
+		}
+		if (host === "www.google.com" || host === "images.google.com") {
+			return false;
+		}
+		if (parsed.searchParams.get("q")?.startsWith("tbn:")) {
+			return false;
+		}
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export const extractGoogleResolvedImageUrl = ({
+	html,
+	baseUrl,
+	googleResultUrl,
+}: {
+	html: string;
+	baseUrl: string;
+	googleResultUrl: string;
+}): string | null => {
+	const candidates: string[] = [];
+	const push = (src: string | null | undefined) => {
+		const resolved = resolveUrl(src, baseUrl);
+		if (resolved && isUsableGoogleResolvedImageUrl(resolved)) {
+			candidates.push(resolved);
+		}
+	};
+
+	if (typeof DOMParser !== "undefined") {
+		const document = new DOMParser().parseFromString(html, "text/html");
+		for (const selector of [
+			'img[jsname="kn3ccd"][src]',
+			"img.iPVvYb[src]",
+			"img.sFlh5c[src]",
+			"img[src]",
+		]) {
+			for (const img of Array.from(document.querySelectorAll(selector))) {
+				push(img.getAttribute("src"));
+			}
+			if (candidates.length) return candidates[0];
+		}
+	} else {
+		const imgTags = [...html.matchAll(/<img\b[^>]*>/gi)].map(
+			(match) => match[0],
+		);
+		const preferred = imgTags.filter((tag) =>
+			/(jsname=["']kn3ccd["']|class=["'][^"']*(?:iPVvYb|sFlh5c)[^"']*["'])/i.test(
+				tag,
+			),
+		);
+		for (const tag of [...preferred, ...imgTags]) {
+			push(attrFromHtml(tag, "src"));
+			if (candidates.length) return candidates[0];
+		}
+	}
+
+	const fallback = fallbackImageUrlFromGoogleImgres(googleResultUrl);
+	return fallback && isUsableGoogleResolvedImageUrl(fallback) ? fallback : null;
+};
+
+type Services = Pick<AllServices, "fs" | "webBrowser">;
 
 export const createHyperframesRemoteAssetImportTool: ToolFactory<
 	Input,
@@ -85,12 +199,59 @@ export const createHyperframesRemoteAssetImportTool: ToolFactory<
 				input.project_path,
 				config?.rootPath,
 			);
+			let downloadUrl = input.url;
+			let resolvedImageUrl: string | undefined;
+
+			if (isGoogleImgresUrl(input.url)) {
+				const webBrowser = requireWebBrowserService(services);
+				let sessionId: string | undefined;
+				try {
+					const opened = await webBrowser.openSession({
+						url: input.url,
+						timeoutMs: DEFAULT_TIMEOUT_MS,
+						maxHtmlChars: MAX_HTML_CHARS,
+						persist: false,
+						mode: "tab",
+					});
+					sessionId = opened.session.id;
+					await webBrowser
+						.waitForPageRender({
+							sessionId,
+							timeoutMs: 5_000,
+							maxHtmlChars: MAX_HTML_CHARS,
+							stabilityMs: 600,
+						})
+						.catch(() => null);
+					const session = await webBrowser.refreshSession({
+						sessionId,
+						timeoutMs: 5_000,
+						maxHtmlChars: MAX_HTML_CHARS,
+					});
+					const resolved = extractGoogleResolvedImageUrl({
+						html: session.html,
+						baseUrl: session.currentUrl || input.url,
+						googleResultUrl: input.url,
+					});
+					if (!resolved) {
+						throw new Error(
+							"Could not resolve a direct image URL from the Google Images result page.",
+						);
+					}
+					resolvedImageUrl = resolved;
+					downloadUrl = resolved;
+				} finally {
+					if (sessionId) {
+						await webBrowser.closeSession(sessionId).catch(() => undefined);
+					}
+				}
+			}
+
 			const { bytes, mimeType, finalUrl } = await downloadResourceBytes({
-				url: input.url,
+				url: downloadUrl,
 				allowedMimeTypes: ["image/*"],
 			});
 			const defaultFilename = sanitizeFilename(
-				filenameFromUrl(input.url, mimeType),
+				filenameFromUrl(downloadUrl, mimeType),
 			);
 			const assetPath = normalizeResourceAssetPath(
 				input.asset_path,
@@ -111,6 +272,7 @@ export const createHyperframesRemoteAssetImportTool: ToolFactory<
 				mimeType,
 				size: bytes.length,
 				url: input.url,
+				...(resolvedImageUrl ? { resolvedImageUrl } : {}),
 				finalUrl,
 			});
 		} catch (error) {

--- a/src/services/flows-core/tools/hyperframes/hyperframes-remote-assets-explore.ts
+++ b/src/services/flows-core/tools/hyperframes/hyperframes-remote-assets-explore.ts
@@ -12,6 +12,7 @@ import {
 const TOOL_NAME = "hyperframes_remote_assets_explore" as const;
 
 const PROVIDERS = [
+	"google_images",
 	"cleanpng",
 	"openverse",
 	"pexels",
@@ -25,6 +26,7 @@ interface Candidate {
 	provider: Provider;
 	url: string;
 	sourceUrl: string;
+	imageUrlPreview?: string;
 	title?: string;
 	alt?: string;
 	width?: number;
@@ -97,6 +99,8 @@ const normalizeQueryForPath = (query: string): string =>
 const providerSearchUrl = (provider: Provider, query: string): string => {
 	const q = query.trim();
 	switch (provider) {
+		case "google_images":
+			return `https://www.google.com/search?udm=2&q=${encodeURIComponent(q)}`;
 		case "cleanpng":
 			return `https://www.cleanpng.com/free/${normalizeQueryForPath(q)}.html`;
 		case "openverse":
@@ -112,9 +116,23 @@ const providerSearchUrl = (provider: Provider, query: string): string => {
 
 const defaultProvidersForKind = (kind: AssetKind): Provider[] => {
 	if (kind === "svg" || kind === "icon" || kind === "illustration") {
-		return ["svgrepo", "cleanpng", "openverse", "pexels", "unsplash"];
+		return [
+			"google_images",
+			"svgrepo",
+			"cleanpng",
+			"openverse",
+			"pexels",
+			"unsplash",
+		];
 	}
-	return ["cleanpng", "openverse", "pexels", "unsplash", "svgrepo"];
+	return [
+		"google_images",
+		"cleanpng",
+		"openverse",
+		"pexels",
+		"unsplash",
+		"svgrepo",
+	];
 };
 
 const toNumber = (value: string | null): number | undefined => {
@@ -149,6 +167,14 @@ const resolveUrl = (value: string | null, baseUrl: string): string | null => {
 	}
 };
 
+const decodeHtmlEntities = (value: string): string =>
+	value
+		.replace(/&amp;/g, "&")
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">");
+
 const normalizeAssetUrl = (url: string, provider: Provider): string => {
 	try {
 		const parsed = new URL(url);
@@ -174,6 +200,21 @@ const isRobotOrBlockedPage = (html: string, text: string): string | null => {
 	const haystack = `${html}\n${text}`.toLowerCase();
 	if (haystack.includes("please respect our robot policy")) {
 		return "robot_policy";
+	}
+	if (
+		haystack.includes("our systems have detected unusual traffic") ||
+		haystack.includes("unusual traffic from your computer network")
+	) {
+		return "unusual_traffic";
+	}
+	if (haystack.includes("captcha") || haystack.includes("not a robot")) {
+		return "captcha";
+	}
+	if (
+		haystack.includes("before you continue to google") ||
+		haystack.includes("consent.google.com")
+	) {
+		return "google_consent";
 	}
 	if (haystack.includes("performing security verification")) {
 		return "security_verification";
@@ -204,6 +245,12 @@ const providerAllowsUrl = (
 		const host = parsed.hostname;
 		const path = parsed.pathname;
 
+		if (provider === "google_images") {
+			return (
+				(host === "www.google.com" || host.endsWith(".google.com")) &&
+				path === "/imgres"
+			);
+		}
 		if (provider === "cleanpng") {
 			return host === "icon2.cleanpng.com";
 		}
@@ -252,6 +299,7 @@ const scoreCandidate = ({
 }): number => {
 	let score = 0;
 	if (provider === "cleanpng") score += 35;
+	if (provider === "google_images") score += 32;
 	if (provider === "openverse") score += 30;
 	if (provider === "pexels") score += 25;
 	if (provider === "unsplash") score += 22;
@@ -262,6 +310,136 @@ const scoreCandidate = ({
 	if (/thumb|w=40|h=40|w=80|h=80/.test(url.toLowerCase())) score -= 15;
 	if (/premium|plus\.unsplash/.test(url.toLowerCase())) score -= 50;
 	return score;
+};
+
+const googleImgresInfoFromUrl = (
+	url: string,
+	baseUrl: string,
+): {
+	url: string;
+	sourceUrl: string;
+	imageUrlPreview?: string;
+	width?: number;
+	height?: number;
+} | null => {
+	const resolved = resolveUrl(decodeHtmlEntities(url), baseUrl);
+	if (!resolved) return null;
+	try {
+		const parsed = new URL(resolved);
+		if (
+			parsed.pathname !== "/imgres" ||
+			!(parsed.hostname === "www.google.com" || parsed.hostname.endsWith(".google.com"))
+		) {
+			return null;
+		}
+		const imageUrlPreview = parsed.searchParams.get("imgurl") ?? undefined;
+		const sourceUrl =
+			parsed.searchParams.get("imgrefurl") ?? imageUrlPreview ?? baseUrl;
+		return {
+			url: parsed.toString(),
+			sourceUrl,
+			imageUrlPreview,
+			width: toNumber(parsed.searchParams.get("w")),
+			height: toNumber(parsed.searchParams.get("h")),
+		};
+	} catch {
+		return null;
+	}
+};
+
+const titleFromHtml = (html: string): string | undefined => {
+	const title = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1];
+	return title ? decodeHtmlEntities(title).trim() || undefined : undefined;
+};
+
+const attrFromHtml = (html: string, attr: string): string | undefined => {
+	const match = new RegExp(`\\b${attr}=([\"'])(.*?)\\1`, "i").exec(html);
+	return match ? decodeHtmlEntities(match[2]) : undefined;
+};
+
+export const extractGoogleImageCandidates = ({
+	html,
+	baseUrl,
+	maxResults,
+}: {
+	html: string;
+	baseUrl: string;
+	maxResults: number;
+}): Candidate[] => {
+	const seen = new Set<string>();
+	const candidates: Candidate[] = [];
+	const title = titleFromHtml(html);
+	const pushCandidate = ({
+		href,
+		innerHtml,
+		alt,
+		width,
+		height,
+	}: {
+		href: string;
+		innerHtml?: string;
+		alt?: string;
+		width?: number;
+		height?: number;
+	}) => {
+		const info = googleImgresInfoFromUrl(href, baseUrl);
+		if (!info || seen.has(info.url)) return;
+		seen.add(info.url);
+		const imgAlt =
+			alt ?? attrFromHtml(innerHtml ?? "", "alt") ?? "";
+		const imgWidth =
+			width ?? toNumber(attrFromHtml(innerHtml ?? "", "width") ?? null);
+		const imgHeight =
+			height ?? toNumber(attrFromHtml(innerHtml ?? "", "height") ?? null);
+		candidates.push({
+			provider: "google_images",
+			url: info.url,
+			sourceUrl: info.sourceUrl,
+			imageUrlPreview: info.imageUrlPreview,
+			title,
+			alt: imgAlt || undefined,
+			width: info.width ?? imgWidth,
+			height: info.height ?? imgHeight,
+			score: scoreCandidate({
+				url: info.url,
+				alt: imgAlt,
+				width: info.width ?? imgWidth,
+				height: info.height ?? imgHeight,
+				provider: "google_images",
+			}),
+		});
+	};
+
+	if (typeof DOMParser !== "undefined") {
+		const document = new DOMParser().parseFromString(html, "text/html");
+		for (const anchor of Array.from(
+			document.querySelectorAll(
+				'a[href*="/imgres"], a[href*="google.com/imgres"]',
+			),
+		)) {
+			const img = anchor.querySelector("img");
+			pushCandidate({
+				href: anchor.getAttribute("href") ?? "",
+				alt: img?.getAttribute("alt") ?? undefined,
+				width: toNumber(img?.getAttribute("width") ?? null),
+				height: toNumber(img?.getAttribute("height") ?? null),
+			});
+			if (candidates.length >= maxResults) break;
+		}
+	} else {
+		const anchorPattern =
+			/<a\b[^>]*\bhref=(["'])([^"']*(?:\/imgres|google\.com\/imgres)[^"']*)\1[^>]*>([\s\S]*?)<\/a>/gi;
+		for (const match of html.matchAll(anchorPattern)) {
+			pushCandidate({
+				href: match[2],
+				innerHtml: match[3],
+			});
+			if (candidates.length >= maxResults) break;
+		}
+	}
+
+	candidates.sort((a, b) => b.score - a.score);
+	return candidates.slice(0, maxResults);
 };
 
 const extractCandidates = ({
@@ -277,6 +455,10 @@ const extractCandidates = ({
 	kind: AssetKind;
 	maxResults: number;
 }): Candidate[] => {
+	if (provider === "google_images") {
+		return extractGoogleImageCandidates({ html, baseUrl, maxResults });
+	}
+
 	const document = new DOMParser().parseFromString(html, "text/html");
 	const seen = new Set<string>();
 	const candidates: Candidate[] = [];

--- a/src/services/flows-core/tools/hyperframes/hyperframes-validate.ts
+++ b/src/services/flows-core/tools/hyperframes/hyperframes-validate.ts
@@ -30,10 +30,12 @@ type Services = Pick<AllServices, "fs">;
 
 // Codes that are always noise in the extension context:
 // - external_script_dependency: fix hint says "no action needed" for CDN-based compositions
+// - missing_gsap_script: runner auto-injects GSAP based on usage detection
 // - invalid_inline_script_syntax: CSP eval() false-positive; our preprocessor handles this
 // - pointer_events_none: intentional for .grain overlay elements
 const SUPPRESSED_CODES = new Set([
 	"external_script_dependency",
+	"missing_gsap_script",
 	"invalid_inline_script_syntax",
 	"pointer_events_none",
 ]);
@@ -197,6 +199,66 @@ const hyperShaderFindings = (html: string): HyperframeFinding[] => {
 	return findings;
 };
 
+const tailwindSafetyFindings = (html: string): HyperframeFinding[] => {
+	const findings: HyperframeFinding[] = [];
+
+	if (
+		/<script\b[^>]*\bsrc=["'][^"']*cdn\.tailwindcss\.com[^"']*["'][^>]*>/i.test(
+			html,
+		) ||
+		/<link\b[^>]*\bhref=["'][^"']*tailwind(?:\.min)?\.css[^"']*["'][^>]*>/i.test(
+			html,
+		)
+	) {
+		findings.push({
+			severity: "warning",
+			code: "manual_tailwind_loader",
+			message:
+				"Tailwind should be authored as classes only; the HyperFrames runner loads Tailwind for preview.",
+			fixHint:
+				"Remove manual Tailwind script/link tags; the preview runner always loads Tailwind with preflight disabled.",
+		});
+	}
+
+	if (
+		/(?:className|classList\s*\.\s*add|setAttribute\s*\(\s*["']class["'])[\s\S]{0,160}(?:\+|`[\s\S]*\$\{)/i.test(
+			html,
+		)
+	) {
+		findings.push({
+			severity: "warning",
+			code: "dynamic_tailwind_class",
+			message:
+				"Dynamic class construction is unreliable with Tailwind browser compilation.",
+			fixHint:
+				"Use literal class strings in HTML so Tailwind can discover every utility before preview/export.",
+		});
+	}
+
+	if (/\bclass=["'][^"']*\banimate-[^\s"']+/i.test(html)) {
+		findings.push({
+			severity: "warning",
+			code: "tailwind_animation_class",
+			message:
+				"Tailwind animation utilities are not deterministic for HyperFrames seeking and MP4 export.",
+			fixHint: "Use GSAP timeline tweens for all scene animation.",
+		});
+	}
+
+	if (/<style\b[\s\S]*?\banimation\s*:[\s\S]*?<\/style>/i.test(html)) {
+		findings.push({
+			severity: "warning",
+			code: "css_animation_property",
+			message:
+				"CSS animation properties are not controlled by the HyperFrames timeline.",
+			fixHint:
+				"Move time-based motion into GSAP so preview scrubbing and export remain deterministic.",
+		});
+	}
+
+	return findings;
+};
+
 const assetFindings = async (
 	html: string,
 	dfs: NonNullable<Services["fs"]>,
@@ -235,6 +297,7 @@ export const lintHyperframesComposition = async (
 	const findings = [
 		...base.findings,
 		...hyperShaderFindings(html),
+		...tailwindSafetyFindings(html),
 		...(await assetFindings(
 			html,
 			dfs,


### PR DESCRIPTION
# 🎬 HyperFrames: Tailwind Runtime + Google Images + Edit Tool

**Branch:** `feat/optimize-video-generate-use-cases` → `main`
**Version:** `0.4.1` → `0.4.2`

---

## 🗂️ Overview

This release wires Tailwind CSS into the HyperFrames preview pipeline as a first-class citizen, adds Google Images as a primary asset source, introduces a targeted `hyperframes_edit` tool, and fixes MP4 export correctness for `object-fit` images — alongside polish to the Copilot overlay and a major simplification of the AI system prompts.

---

## ✨ What's New

### 🎨 Tailwind Browser Runtime in HyperFrames Preview

The preview runner now automatically loads the [Tailwind browser compiler](https://cdn.tailwindcss.com) as **Step 1** of the render pipeline — before GSAP, scripts, or the HyperFrames runtime. Preflight is disabled so existing direct-CSS compositions are unaffected.

- **Theme bridge** — Custom Tailwind utilities (`bg-hf-bg`, `text-hf-ink`, `text-hf-accent`, `text-hf-muted`, `font-hf-display`, `font-hf-data`) are mapped directly to the composition's CSS variables.
- **Readiness probe** — `waitForTailwindReady()` injects a hidden probe element and verifies Tailwind styles are applied before the first frame renders, preventing blank-frame captures on first load.
- **Managed script detection** — `isTailwindScript()` prevents duplicate injection of `cdn.tailwindcss.com` scripts authored in compositions.
- **Validator rules** — New lint findings guard against misuse:
  | Code | Severity | Catches |
  |---|---|---|
  | `manual_tailwind_loader` | ⚠️ warning | `<script src="cdn.tailwindcss.com">` in composition HTML |
  | `dynamic_tailwind_class` | ⚠️ warning | JS that builds class strings at runtime (e.g. `"bg-" + color`) |
  | `tailwind_animation_class` | ⚠️ warning | `animate-*` utilities (conflicts with GSAP timeline) |
  | `css_animation_property` | ⚠️ warning | `animation:` in `<style>` blocks |

---

### 🖼️ Google Images as Primary Asset Source

`hyperframes_remote_assets_explore` now tries **Google Images first**, then falls back automatically to the existing providers (CleanPNG, Openverse, Pexels, Unsplash) when Google is blocked or returns too few usable candidates.

- Candidates are parsed from Google `/search?udm=2` results, including `alt`, `width`, `height`, `sourceUrl`, and `imageUrlPreview`.
- Unusual-traffic detection (`"Our systems have detected unusual traffic"`) triggers an immediate fallback with a `reason: "unusual_traffic"` attempt record.

`hyperframes_remote_asset_import` now resolves actual image URLs from Google `/imgres` result pages:

- Opens the result page in a browser session, reads the rendered HTML, and extracts the best non-gstatic image via DOM selectors (`img[jsname="kn3ccd"]`, `img.iPVvYb`, `img.sFlh5c`).
- Falls back to the decoded `imgurl` query parameter when DOM extraction yields nothing.
- Rejects thumbnails from `encrypted-tbn*.gstatic.com` and Google's own domains.

---

### ✏️ New `hyperframes_edit` Tool

A targeted surgical-edit tool that replaces an exact string inside `index.html` without a full rewrite — analogous to the `Edit` tool in the main extension.

```
hyperframes_edit(project_path, old_string, new_string, replace_all?)
```

- Fails fast with a clear error when `old_string` is not found.
- `replace_all: true` replaces every occurrence (useful for renames across a composition).
- Registered in the tool registry and surfaced in the HyperFrames feature tool list.

---

### 📸 Fix: `object-fit` Images in MP4 Export

html2canvas does not honour `object-fit` when capturing frames, causing images to appear stretched or incorrectly sized in exported videos.

`preserveObjectFitImagesForHtml2Canvas` is now passed as the `onclone` callback during MP4 export. It converts each `<img>` with `object-fit` into an equivalent `background-image` + `background-size` approach in the cloned document:

| `object-fit` value | → `background-size` |
|---|---|
| `cover` | `cover` |
| `contain` / `scale-down` | `contain` |
| `none` | `auto` |

The original `src` is replaced with a 1×1 transparent SVG data URI so the `<img>` element becomes invisible while the background renders correctly.

---

## 🤖 AI System Prompt Improvements

### HyperFrames Feature

- **Tailwind-first authoring** — The prompt now specifies Tailwind as the default styling language with full guidance: which utilities to prefer, how to use HF theme tokens, when to keep a `<style>` block, and why dynamic class building is forbidden.
- **`hyperframes_init` scaffold templates** — Replaced four inline skeleton code blocks with a concise decision table mapping format/duration to named scaffold and styled templates. Agents call `hyperframes_init` with the right template name rather than copying boilerplate.
- **Cleaner tool strategy table** — Collapsed the "Core composition lifecycle" and "Agent goals" sections into a single compact table. Added `hyperframes_edit` to the recommended edit flow.
- **Google Images guidance** — Updated remote asset workflow to note that Google Images candidates use `/imgres` URLs and that `imageUrlPreview` is informational only.
- **Self-review checklist** — Added two new items: Tailwind classes must be literal strings, and no `animate-*` utilities should appear in compositions.

### FS Feature

The filesystem access system prompt was condensed by ~75% — removing duplicate explanations, verbose tables, and redundant examples — while keeping all the essential strategy rules (discover broad → narrow, read before edit, prefer targeted edits, etc.).

---

## 💅 Copilot Overlay Polish

### `CopilotOverlay`

- Extracted `shouldUseSpotlight` boolean — now also excludes **large targets** (width > 45% viewport, height > 70% viewport) from the spotlight path, not just body targets.
- Solid backdrop gains `backdrop-blur-[1px]` for a softer feel on full-screen and large-element overlays.
- Spotlight SVG mask opacity nudged from `0.50` → `0.55` for slightly stronger focus.

### `CopilotTooltip`

- Removed `backdrop-blur-xl` and changed `bg-background/95` → `bg-background` for a crisper, non-frosted tooltip card.

---

## 🧪 Tests

New test coverage added to `hyperframes.test.ts`:

| Test | What it verifies |
|---|---|
| `extractGoogleImageCandidates` | Parses `/imgres` links from Google Images HTML |
| `extractGoogleResolvedImageUrl` | Extracts best image from rendered imgres DOM |
| `falls back to imgurl query param` | Full import pipeline when DOM extraction fails |
| `falls back to other providers when Google is blocked` | Unusual-traffic detection triggers fallback |
| `direct image imports work without browser service` | Non-Google URLs unaffected by new Google path |
| `accepts Tailwind static classes` | Validator passes compositions with Tailwind utilities |
| `warns on manual Tailwind loader` | `manual_tailwind_loader` finding fires |
| `warns on dynamic Tailwind classes` | `dynamic_tailwind_class` finding fires |
| `warns on Tailwind/CSS animation utilities` | Both `tailwind_animation_class` and `css_animation_property` fire |

---

## 📝 Files Changed

| Area | Files |
|---|---|
| 🏷️ Version | `manifest.json`, `package.json` |
| 🎬 Preview runner | `runner/hyperframes-preview.html`, `runner/js/hyperframes-preview.js` |
| ✏️ New edit tool | `src/services/flows-core/tools/hyperframes/hyperframes-edit.ts` *(new)* |
| 🖼️ Remote assets | `hyperframes-remote-asset-import.ts`, `hyperframes-remote-assets-explore.ts` |
| 🔍 Validator | `hyperframes-validate.ts` |
| 🤖 System prompts | `hyperframes-feature.ts`, `fs-feature.ts` |
| 🧪 Tests | `__tests/tools/hyperframes.test.ts` |
| 💅 Copilot UI | `CopilotOverlay.tsx`, `CopilotTooltip.tsx` |

---

## 🧪 Test Plan

- [x] Open a new HyperFrames project and write a composition using Tailwind classes — preview renders with correct styles applied
- [x] Export an MP4 containing an `object-fit: cover` image — verify image fills its container correctly in the exported video
- [x] Use `hyperframes_remote_assets_explore` — confirm Google Images candidates appear first in results
- [x] Import a Google `/imgres` URL with `hyperframes_remote_asset_import` — confirm the actual image (not a thumbnail) is saved locally
- [x] Simulate Google unusual-traffic response — confirm fallback to CleanPNG is logged
- [x] Use `hyperframes_edit` to make a targeted change — confirm old_string is replaced without touching the rest of the file
- [x] Trigger Copilot overlay on a small element, a large element, and the body — confirm spotlight/solid-backdrop switching is correct
- [x] Run `hyperframes_validate` on a composition with `<script src="https://cdn.tailwindcss.com">` — confirm `manual_tailwind_loader` warning appears
- [x] Run `pnpm test` — all new unit tests pass

---

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)
