### PR TITLE
Document the standalone Agent Harness package family

### DIFF
--- a/packages/agent-harness/README.md
+++ b/packages/agent-harness/README.md
@@ -1,0 +1,181 @@
+# ⚡ Agent Harness
+
+> A composable, side-effect-free runtime for building tool-using agents that run
+> in browsers, workers, and Node.js.
+
+**Status:** private Yarn workspace family · **Version:** `0.1.0` · **Runtime:**
+ESM, modern browsers/workers, Node.js 22+
+
+Agent Harness turns a model API into a controlled execution system. It owns
+plugin composition, graph execution, tools, services, streaming events,
+cancellation, deadlines, checkpoints, and sandbox lifecycle. Applications keep
+their prompts, data models, UI, persistence policy, and provider credentials.
+
+## ✨ Why Use It?
+
+- 🧩 **Compose explicitly:** install only the graphs and capabilities an agent needs.
+- 🌍 **Run anywhere:** keep universal code free of DOM, Chrome, and Node assumptions.
+- 🔌 **Replace providers:** bind models, filesystems, browsers, MCP servers, and
+  sandboxes through stable service ports.
+- 📡 **Observe every run:** consume JSON-safe model, tool, usage, and lifecycle events.
+- 🛑 **Stay in control:** propagate cancellation, deadlines, output limits, and cleanup.
+- 🧪 **Test with confidence:** reuse fake services and provider conformance suites.
+- 📦 **Scale gradually:** start with the full facade, then import focused packages
+  when bundle size or ownership requires it.
+
+## 🧭 Choose Your Package
+
+| Package | Icon | Use it for |
+|---|:---:|---|
+| [`@memorall/agent-harness`](./full/README.md) | 🚀 | The easiest complete facade and explicit presets |
+| [`@memorall/agent-harness-core`](./core/README.md) | ⚙️ | Contracts, plugins, runs, events, lifecycle, and persistence ports |
+| [`@memorall/agent-harness-langgraph`](./langgraph/README.md) | 🔁 | ReAct agent loops and ordered step pipelines backed by LangGraph |
+| [`@memorall/agent-harness-standard`](./standard/README.md) | 🧰 | Filesystem, web, planner, skills, chat, compaction, and delegation capabilities |
+| [`@memorall/agent-harness-sandbox`](./sandbox/README.md) | 🧪 | Provider-neutral sandbox sessions, tools, profiles, and workspace sync |
+| [`@memorall/agent-harness-mcp`](./mcp/README.md) | 🔌 | HTTP/SSE MCP discovery, lifecycle, and structured tool adaptation |
+| [`@memorall/agent-harness-browser`](./browser/README.md) | 🌐 | Browser/worker platform, OPFS, IndexedDB, and DOM content adapters |
+| [`@memorall/agent-harness-node`](./node/README.md) | 🟢 | Node platform, filesystem, stores, stdio MCP, Playwright, and local sandbox |
+| [`@memorall/agent-harness-compat`](./compatibility/README.md) | 🧭 | Explicit bridges for legacy graph, step, and tool IDs |
+
+### Fastest path
+
+Use the full facade plus one platform package:
+
+```text
+Browser app  → agent-harness + agent-harness-browser
+Node service → agent-harness + agent-harness-node
+Library      → agent-harness-core + only the plugins it needs
+```
+
+All packages are private in this repository today. Internal dependencies use
+`workspace:^`; their manifests and exports are ready for later independent
+publication.
+
+## 🚀 Quick Start
+
+This Node example runs the generic `agent` graph with a model adapter. A real
+adapter can call any provider as long as it implements `ModelService`.
+
+```ts
+import {
+  MODEL_SERVICE,
+  createFullHarness,
+  type ModelService,
+} from "@memorall/agent-harness";
+import { createNodePlatform } from "@memorall/agent-harness-node";
+
+const model: ModelService = {
+  async *stream(request) {
+    const last = request.messages.at(-1)?.content ?? "";
+    yield { type: "text.delta", text: `Received: ${String(last)}` };
+    yield {
+      type: "completed",
+      message: { role: "assistant", content: `Received: ${String(last)}` },
+    };
+  },
+};
+
+const harness = createFullHarness({
+  platform: createNodePlatform(),
+  preset: {
+    standard: false,
+    sandbox: false,
+    mcp: false,
+  },
+  services: {
+    [MODEL_SERVICE.id]: model,
+  },
+});
+
+const run = harness.run({
+  graph: "agent",
+  input: {
+    messages: [{ role: "user", content: "Hello, harness" }],
+  },
+});
+
+for await (const event of run) {
+  if (event.type === "model.delta") console.log(event.delta);
+}
+
+console.log(await run.result());
+await harness.close();
+```
+
+The harness is intentionally model-provider neutral. Convert provider streams
+into `ModelStreamEvent` values at the adapter boundary.
+
+## 🏗️ How It Fits Together
+
+```mermaid
+flowchart LR
+    Host["🏠 Host application"]
+    Facade["🚀 Full facade or focused plugins"]
+    Core["⚙️ Harness core"]
+    Graph["🔁 Graph driver"]
+    Tools["🧰 Capability plugins"]
+    Ports["🔌 Service ports"]
+    Providers["🌐 Browser, Node, local, or remote providers"]
+
+    Host --> Facade
+    Facade --> Core
+    Graph --> Core
+    Tools --> Core
+    Core --> Ports
+    Ports --> Providers
+```
+
+The dependency direction always points toward `core`. Universal packages never
+import application code or concrete platform services.
+
+## 🧠 Core Concepts
+
+| Concept | Responsibility |
+|---|---|
+| **Harness instance** | Owns frozen plugins, registries, services, limits, and stores |
+| **Run** | Owns input, scope, cancellation, deadline, events, runtime state, and result |
+| **Graph** | Coordinates model calls, tools, steps, and checkpoint state |
+| **Plugin** | Explicitly registers graphs, steps, tools, and service requirements |
+| **Service token** | Connects a portable capability to a host implementation |
+| **Tool** | Validates model input and returns text plus optional structured content |
+| **Platform** | Supplies clock, UUID, scheduling, and optional fetch primitives |
+| **Provider session** | Holds replaceable browser, local, or remote execution state |
+
+## 🛡️ Runtime Guarantees
+
+- Imports do not mutate global registries or install features.
+- Every harness instance owns frozen registries and service bindings.
+- Events, public errors, IDs, cursors, and checkpoints are JSON-serializable.
+- One `AbortSignal` and deadline flow through graphs, models, tools, and providers.
+- Bounded queues and output limits prevent unlimited model-context growth.
+- Tools enter a model call only through explicit graph and capability selection.
+- Browser and Node implementations satisfy the same portable contracts.
+
+## 🧪 Develop And Verify
+
+Run these commands from the repository root:
+
+```bash
+corepack enable
+yarn install --immutable
+yarn harness:boundaries
+yarn harness:typecheck
+yarn harness:test
+yarn harness:pack
+yarn harness:smoke
+```
+
+`yarn check:agent-harness` runs the complete package contract. Packed-consumer
+smoke tests install generated tarballs into clean Node, Vite, Web Worker, and
+Service Worker fixtures, so repository aliases or undeclared dependencies cannot
+hide packaging defects.
+
+## 📚 More Documentation
+
+- [Agent Harness Architecture](../../docs/agent-harness-architecture.md)
+- [Sandbox Architecture Review](../../docs/agent-harness-sandbox-review.md)
+- [Memorall compatibility runtime](../../src/services/flows-legacy/README.md)
+
+Start with the [full facade](./full/README.md) for application development, or
+open the [core package](./core/README.md) when designing a new graph driver or
+capability plugin.

--- a/packages/agent-harness/browser/README.md
+++ b/packages/agent-harness/browser/README.md
@@ -1,5 +1,62 @@
-# Agent Harness Browser
+# 🌐 Agent Harness Browser
 
-Standard Web API adapters for browser and worker hosts: platform primitives,
-OPFS filesystem access, IndexedDB persistence, and DOM content processing. This
-package does not use Chrome extension APIs.
+> Browser and worker adapters built only on standard Web APIs.
+
+[← Workspace guide](../README.md) · **Package:** `@memorall/agent-harness-browser`
+
+This package connects portable harness contracts to browser primitives. It does
+not import Chrome extension APIs, application services, React, or a model SDK.
+
+## ✨ Included Adapters
+
+| Export | Purpose | Page | Worker |
+|---|---|:---:|:---:|
+| `createBrowserPlatform()` | clock, UUID, timers, optional fetch | ✅ | ✅ |
+| `OpfsFileSystem` | portable filesystem backed by OPFS | ✅ | ✅* |
+| `IndexedDbCheckpointStore` | durable run checkpoints | ✅ | ✅ |
+| `IndexedDbEventStore` | durable paginated run events | ✅ | ✅ |
+| `DomHtmlContentProcessor` | selector-based text/clean HTML extraction | ✅ | ❌ |
+
+`*` OPFS availability depends on the target browser and worker context.
+
+## 🚀 Compose A Browser Host
+
+```ts
+import {
+  DomHtmlContentProcessor,
+  IndexedDbCheckpointStore,
+  IndexedDbEventStore,
+  OpfsFileSystem,
+  createBrowserPlatform,
+} from "@memorall/agent-harness-browser";
+import {
+  FILESYSTEM_SERVICE,
+  HTML_CONTENT_PROCESSOR,
+} from "@memorall/agent-harness-standard";
+
+const platform = createBrowserPlatform();
+const checkpointStore = new IndexedDbCheckpointStore({
+  databaseName: "my-agent",
+});
+const eventStore = new IndexedDbEventStore({ databaseName: "my-agent" });
+
+const services = {
+  [FILESYSTEM_SERVICE.id]: new OpfsFileSystem(),
+  [HTML_CONTENT_PROCESSOR.id]: new DomHtmlContentProcessor(),
+};
+```
+
+Pass these values to `createHarness()` or `createFullHarness()`. Supply a model
+adapter separately through `MODEL_SERVICE`.
+
+## 🧵 Worker Guidance
+
+Create the platform with `runtime: "worker"` when auto-detection is not
+appropriate. Do not bind `DomHtmlContentProcessor` where `DOMParser` is absent;
+inject another `HtmlContentProcessor` or leave DOM extraction unadvertised.
+
+## 🛡️ Boundary
+
+Browser extension tabs, service-worker messaging, offscreen documents, and
+AlmostNode transports are host adapters, not responsibilities of this package.
+That separation keeps the same harness usable in a normal web app.

--- a/packages/agent-harness/compatibility/README.md
+++ b/packages/agent-harness/compatibility/README.md
@@ -1,4 +1,55 @@
-# Agent Harness Compatibility
+# 🧭 Agent Harness Compatibility
 
-Explicit legacy ID declarations and host-supplied registration bridges. Importing
-this package does not enable compatibility behavior or application code.
+> Preserve old public IDs while moving execution to explicit harness plugins.
+
+[← Workspace guide](../README.md) · **Package:** `@memorall/agent-harness-compat`
+
+Compatibility is an opt-in bridge for stored flows and external integrations.
+It declares known legacy graph, step, and container-tool IDs, then registers
+implementations supplied by the host. It contains no application prompts,
+persistence rules, browser services, or hidden fallback behavior.
+
+## ✨ What It Preserves
+
+- legacy graph IDs such as `foundation` and `agent`;
+- established step IDs used by stored flow definitions;
+- deprecated `container_*` tool IDs during a migration window;
+- the host's existing implementations and semantics.
+
+## 🚀 Register A Bridge
+
+```ts
+import { createHarness } from "@memorall/agent-harness-core";
+import { compatibilityPlugin } from "@memorall/agent-harness-compat";
+
+const compatibility = compatibilityPlugin({
+  graphs: [legacyFoundationGraph],
+  steps: [legacySystemStep],
+  tools: {
+    container_run_code: () => legacyContainerRunTool,
+  },
+});
+
+const harness = createHarness({
+  platform,
+  plugins: [compatibility],
+  services,
+});
+```
+
+Nothing happens at import time. If the compatibility plugin is omitted, legacy
+IDs are unavailable by design.
+
+## 🛡️ Migration Rules
+
+1. Keep new graphs and tools on current IDs.
+2. Enable compatibility only for hosts that load stored legacy definitions.
+3. Keep deprecated `container_*` tools out of new model profiles.
+4. Measure legacy usage before removing an ID.
+5. Remove bridges in a versioned migration, never through silent replacement.
+
+## 🚫 What This Package Is Not
+
+It is not a global registry, automatic data migration, provider adapter, or
+application compatibility layer. The host remains responsible for supplying and
+eventually retiring each legacy implementation.

--- a/packages/agent-harness/core/README.md
+++ b/packages/agent-harness/core/README.md
@@ -1,6 +1,90 @@
-# Agent Harness Core
+# ⚙️ Agent Harness Core
 
-Environment-neutral contracts and runtime orchestration for the Memorall agent
-harness package family. Importing this package has no registration side effects.
+> The small, environment-neutral kernel behind every Agent Harness application.
 
-Use `createHarness()` with explicit plugins, services, and a `HarnessPlatform`.
+[← Workspace guide](../README.md) · **Package:** `@memorall/agent-harness-core`
+
+Core owns contracts and orchestration, not product behavior. It creates isolated
+harness instances, installs explicit plugins, freezes registries, starts runs,
+streams events, validates tools, propagates cancellation, and coordinates
+checkpoints and cleanup.
+
+## ✨ Use Core When
+
+- you are building a custom graph driver or capability plugin;
+- you need the smallest browser/worker bundle;
+- you want complete control over graphs, tools, limits, and services;
+- you are implementing a remote transport against stable JSON-safe contracts.
+
+## 🚀 Minimal Run
+
+```ts
+import {
+  createHarness,
+  type HarnessPlugin,
+} from "@memorall/agent-harness-core";
+import { createNodePlatform } from "@memorall/agent-harness-node";
+
+const echoPlugin: HarnessPlugin = {
+  id: "example.echo",
+  version: "1.0.0",
+  register({ registerGraph }) {
+    registerGraph({
+      id: "echo",
+      version: "1.0.0",
+      async execute({ input }) {
+        return { output: String(input) };
+      },
+    });
+  },
+};
+
+const harness = createHarness({
+  platform: createNodePlatform(),
+  plugins: [echoPlugin],
+});
+
+const result = await harness.run({ graph: "echo", input: "Hello" }).result();
+console.log(result.output); // Hello
+await harness.close();
+```
+
+## 🧱 Public Building Blocks
+
+| Area | Key exports |
+|---|---|
+| Runs | `createHarness`, `AgentHarness`, `HarnessRun`, `HarnessRunRequest` |
+| Plugins | `HarnessPlugin`, `HarnessPluginRegistrar`, `installPlugins` |
+| Graphs and steps | `HarnessGraphDefinition`, `HarnessStepDefinition` |
+| Tools | `BaseTool`, `ToolExecutionResult`, `jsonToolSchema`, `executeTool` |
+| Services | `createServiceToken`, `ServiceResolver`, `MODEL_SERVICE` |
+| Runtime | `RunContext`, `RunLifecycle`, `HarnessPlatform`, `HarnessLimits` |
+| Persistence | `HarnessCheckpointStore`, `HarnessEventStore` |
+| Observability | `HarnessEvent`, `HarnessEventSink`, serialized harness errors |
+
+## 🧩 Plugin Rules
+
+Plugins register runtime string IDs without ambient type augmentation. Install
+validates duplicate IDs, missing dependencies, semver requirements, and cycles
+before the first run. Registries freeze after construction, so concurrent
+harness instances cannot observe each other's tools or state.
+
+## 🧪 Testing
+
+The `@memorall/agent-harness-core/testing` subpath exports deterministic test
+primitives:
+
+```ts
+import {
+  MemoryCheckpointStore,
+  MemoryEventStore,
+  createTestPlatform,
+} from "@memorall/agent-harness-core/testing";
+```
+
+## 🌍 Runtime Boundary
+
+Core uses ES modules and portable Web Platform primitives. It does not import
+LangGraph, React, DOM APIs, Chrome APIs, Node built-ins, provider SDKs, or
+application code. Choose [`browser`](../browser/README.md) or
+[`node`](../node/README.md) for concrete platform adapters.

--- a/packages/agent-harness/full/README.md
+++ b/packages/agent-harness/full/README.md
@@ -1,4 +1,82 @@
-# Agent Harness
+# 🚀 Agent Harness Full Facade
 
-Side-effect-free facade for the tested core, LangGraph, standard capability,
-sandbox, and MCP packages. Use `fullHarnessPreset()` for explicit composition.
+> The shortest path from a model adapter to a production-shaped agent runtime.
+
+[← Workspace guide](../README.md) · **Package:** `@memorall/agent-harness`
+
+The full facade re-exports core, LangGraph, standard capabilities, sandbox, and
+MCP APIs. It stays side-effect free: importing it registers nothing. Calling
+`fullHarnessPreset()` creates plugin descriptors; calling `createFullHarness()`
+builds one isolated harness instance.
+
+## ✨ Best For
+
+- applications that want the complete tested package family;
+- prototypes that may later split into focused imports;
+- hosts that need one clear composition point for browser and Node runtimes.
+
+## 🚀 Create A Harness
+
+```ts
+import {
+  FILESYSTEM_SERVICE,
+  MODEL_SERVICE,
+  createFullHarness,
+} from "@memorall/agent-harness";
+import {
+  NodeFileSystem,
+  createNodePlatform,
+} from "@memorall/agent-harness-node";
+
+const harness = createFullHarness({
+  platform: createNodePlatform(),
+  preset: {
+    standard: {
+      web: false,
+      skills: false,
+      multiAgent: false,
+    },
+    sandbox: false,
+    mcp: false,
+  },
+  services: {
+    [MODEL_SERVICE.id]: modelService,
+    [FILESYSTEM_SERVICE.id]: new NodeFileSystem(),
+  },
+});
+```
+
+## 🎛️ Preset Switches
+
+| Option | Default | Controls |
+|---|---:|---|
+| `langgraph` | enabled | Generic `agent` graph and optional linear graph |
+| `standard` | enabled | Chat, files, web, planner, skills, compaction, delegation |
+| `sandbox` | enabled | Capability-gated `web_app` sandbox tool profile |
+| `mcp` | omitted | MCP tools supplied as discovered descriptors |
+| `plugins` | `[]` | Host or domain plugins appended explicitly |
+
+Set a capability to `false` to leave it out completely. Registered capability
+does not mean automatic model exposure: graph configuration and provider
+capabilities still choose the final tool list.
+
+## 🔍 Inspect Before Running
+
+```ts
+const descriptor = harness.inspect();
+
+console.table(descriptor.graphs);
+console.table(descriptor.tools);
+console.log(descriptor.requiredServices);
+```
+
+Inspection makes composition errors visible before a model call. Missing
+required services fail with stable harness errors instead of provider-specific
+exceptions.
+
+## 🧭 Go Deeper
+
+- Start with [`core`](../core/README.md) to author plugins.
+- Read [`standard`](../standard/README.md) to select tools precisely.
+- Read [`sandbox`](../sandbox/README.md) before binding a runtime provider.
+- Use [`browser`](../browser/README.md) or [`node`](../node/README.md) for host adapters.

--- a/packages/agent-harness/langgraph/README.md
+++ b/packages/agent-harness/langgraph/README.md
@@ -1,5 +1,82 @@
-# Agent Harness LangGraph
+# 🔁 Agent Harness LangGraph
 
-LangGraph-backed ReAct and ordered-step graph implementations for the standalone
-agent harness. This package adapts LangGraph execution to engine-neutral harness
-events and contains no application policy.
+> Generic ReAct and ordered-step graphs, adapted to engine-neutral harness events.
+
+[← Workspace guide](../README.md) · **Package:** `@memorall/agent-harness-langgraph`
+
+This package is the graph driver. LangGraph stays behind the package boundary;
+hosts consume `HarnessEvent` values and never need to parse LangGraph chunks.
+No prompts, memory policy, product state, or application services live here.
+
+## ✨ What You Get
+
+| Graph | Default ID | Purpose |
+|---|---|---|
+| ReAct agent | `agent` | Stream a model, assemble tool calls, execute tools, and loop |
+| Linear graph | `linear` | Run an explicit ordered list of registered harness steps |
+| Stream adapter | n/a | Convert graph activity into stable harness events |
+
+## 🚀 Agent Loop
+
+```ts
+import {
+  MODEL_SERVICE,
+  createHarness,
+  type ModelService,
+} from "@memorall/agent-harness-core";
+import { langGraphPlugin } from "@memorall/agent-harness-langgraph";
+import { createNodePlatform } from "@memorall/agent-harness-node";
+
+const model: ModelService = {
+  async *stream() {
+    yield {
+      type: "completed",
+      message: { role: "assistant", content: "Done" },
+    };
+  },
+};
+
+const harness = createHarness({
+  platform: createNodePlatform(),
+  plugins: [langGraphPlugin({ agent: { maxRetries: 1 } })],
+  services: { [MODEL_SERVICE.id]: model },
+});
+
+const run = harness.run({
+  graph: "agent",
+  input: { messages: [{ role: "user", content: "Complete this task" }] },
+});
+
+for await (const event of run) console.log(event.type);
+```
+
+## 🛠️ Configure The Agent
+
+`AgentGraphOptions` can set a custom graph ID/version, default model, system
+prompt, tool allowlist, description, and retry count. Run input may override the
+model, system prompt, and tools for one invocation.
+
+Parallel execution is allowed only when tools declare `parallelSafeHint` and
+the configured harness limits permit it. Retries require both an idempotent tool
+annotation and a retryable error.
+
+## 📏 Linear Pipelines
+
+```ts
+langGraphPlugin({
+  agent: false,
+  linear: {
+    id: "prepare-request",
+    steps: ["add-system", "current-time"],
+  },
+});
+```
+
+Steps come from explicit plugins such as
+[`@memorall/agent-harness-standard`](../standard/README.md). Missing steps or
+services fail before partial pipeline execution can silently continue.
+
+## 🌍 Runtime Boundary
+
+The package works in browsers, workers, and Node.js. It depends on LangGraph and
+core only; provider SDKs and application policy belong in host adapters.

--- a/packages/agent-harness/mcp/README.md
+++ b/packages/agent-harness/mcp/README.md
@@ -1,4 +1,63 @@
-# Agent Harness MCP
+# 🔌 Agent Harness MCP
 
-Browser-compatible HTTP and SSE MCP client lifecycle, async tool discovery, and
-structured MCP tool adaptation for immutable harness instances.
+> Discover MCP tools, preserve their structured results, and install them as
+> explicit harness plugins.
+
+[← Workspace guide](../README.md) · **Package:** `@memorall/agent-harness-mcp`
+
+This package provides browser-compatible Streamable HTTP and SSE transports,
+connection lifecycle, paginated tool discovery, JSON Schema validation, stable
+tool naming, and MCP-to-harness result adaptation.
+
+## 🚀 Discover And Register Tools
+
+```ts
+import {
+  MCP_TOOL_SERVICE,
+  McpClientManager,
+  mcpPlugin,
+} from "@memorall/agent-harness-mcp";
+
+const mcp = new McpClientManager(
+  [{ id: "docs", url: "https://example.com/mcp", transport: "http" }],
+  { prefixToolNames: true },
+);
+
+const descriptors = await mcp.discover();
+const plugins = [mcpPlugin(descriptors)];
+const services = { [MCP_TOOL_SERVICE.id]: mcp };
+
+// Pass plugins and services to createHarness(), then close when the host exits.
+await mcp.close();
+```
+
+With prefixes enabled, a server tool such as `search` becomes `docs__search`,
+which prevents collisions when several servers expose common names.
+
+## ✨ Preserved MCP Data
+
+| MCP field | Harness destination |
+|---|---|
+| text/content blocks | model-facing tool content |
+| `structuredContent` | `ToolExecutionResult.structuredContent` |
+| `_meta` | structured result metadata |
+| input/output schemas | tool validation and public schema |
+| annotations | read-only, destructive, idempotent, open-world hints |
+| icons | tool display metadata |
+
+Agents and UI code do not need to parse terminal prose to recover MCP results.
+
+## 🌐 Transport Choices
+
+- Use Streamable HTTP by default.
+- Select `transport: "sse"` for compatible legacy servers.
+- Inject `fetch` when credentials, testing, or a custom network stack requires it.
+- Configure bounded reconnect attempts through `reconnect` options.
+- Use [`McpStdioClientManager`](../node/README.md) from the Node package for stdio.
+
+## 🛡️ Lifecycle Boundary
+
+Discovery is asynchronous, so build descriptors before constructing the
+immutable harness. The host owns authentication, server configuration, connect,
+reconnect, and close behavior. Importing this package opens no connections and
+registers no tools.

--- a/packages/agent-harness/node/README.md
+++ b/packages/agent-harness/node/README.md
@@ -1,4 +1,81 @@
-# Agent Harness Node
+# 🟢 Agent Harness Node
 
-Node 22+ platform, filesystem, durable stores, MCP stdio, local process sandbox,
-and optional Playwright adapters for the standalone agent harness.
+> Production-ready Node.js adapters for portable harness contracts.
+
+[← Workspace guide](../README.md) · **Package:** `@memorall/agent-harness-node`
+
+Use this package at a Node host boundary. Universal graphs and tools stay in
+their focused packages; Node-specific filesystem, process, stdio, and Playwright
+implementations live here.
+
+## ✨ Included Adapters
+
+| Export | Purpose |
+|---|---|
+| `createNodePlatform()` | Node clock, UUID, scheduling, and fetch primitives |
+| `NodeFileSystem` | `node:fs/promises` implementation of `HarnessFileSystem` |
+| `FileCheckpointStore` | atomic JSON checkpoint persistence |
+| `FileEventStore` | serialized per-run event persistence |
+| `NodeLocalSandboxProvider` | capability-gated local process sandbox provider |
+| `McpStdioClientManager` | MCP client lifecycle over child-process stdio |
+| `PlaywrightWebBrowserService` | optional browser automation via `./playwright` |
+
+## 🚀 Compose A Node Host
+
+```ts
+import { FILESYSTEM_SERVICE } from "@memorall/agent-harness-standard";
+import {
+  FileCheckpointStore,
+  FileEventStore,
+  NodeFileSystem,
+  createNodePlatform,
+} from "@memorall/agent-harness-node";
+
+const harnessOptions = {
+  platform: createNodePlatform(),
+  checkpointStore: new FileCheckpointStore(".agent-state"),
+  eventStore: new FileEventStore(".agent-state"),
+  services: {
+    [FILESYSTEM_SERVICE.id]: new NodeFileSystem(),
+  },
+};
+```
+
+## 🧪 Local Sandbox
+
+```ts
+import { NodeLocalSandboxProvider } from "@memorall/agent-harness-node";
+
+const provider = new NodeLocalSandboxProvider({
+  id: "node-local",
+  maxOutputChars: 200_000,
+});
+```
+
+Register the provider through
+[`SandboxProviderRegistry`](../sandbox/README.md). Models still use the same
+grouped `sandbox_*` tools as browser or remote providers.
+
+## 🔌 MCP Stdio
+
+`McpStdioClientManager` is intentionally Node-only. HTTP and SSE remain in the
+universal [`MCP package`](../mcp/README.md), so browser bundles never inherit
+`child_process`.
+
+## 🎭 Optional Playwright
+
+Import Playwright support explicitly:
+
+```ts
+import { PlaywrightWebBrowserService } from "@memorall/agent-harness-node/playwright";
+```
+
+The main entry point does not force Playwright into consumers that only need
+filesystem or persistence adapters.
+
+## 📏 Requirements
+
+- Node.js 22 or newer
+- ESM
+- host-managed filesystem permissions and process lifecycle
+- explicit service/plugin composition through core

--- a/packages/agent-harness/sandbox/README.md
+++ b/packages/agent-harness/sandbox/README.md
@@ -1,5 +1,82 @@
-# Agent Harness Sandbox
+# 🧪 Agent Harness Sandbox
 
-Provider-neutral sandbox sessions, capabilities, workspace synchronization,
-grouped model tools, profiles, normalized errors, and provider conformance
-utilities. Concrete browser and cloud transports are external adapters.
+> One stable sandbox contract for browser, local, remote, and future providers.
+
+[← Workspace guide](../README.md) · **Package:** `@memorall/agent-harness-sandbox`
+
+The sandbox package owns orchestration, not a concrete runtime. It manages
+provider registration, reusable sessions, capabilities, opaque IDs, process
+cursors, workspace synchronization, normalized errors, grouped model tools, and
+provider conformance tests.
+
+## 🏗️ Architecture
+
+```mermaid
+flowchart LR
+    Tools["🤖 sandbox_* tools"] --> Service["IAgentSandboxService"]
+    Service --> Manager["SandboxManager"]
+    Manager --> Registry["SandboxProviderRegistry"]
+    Manager --> Workspace["SandboxWorkspaceCoordinator"]
+    Registry --> Local["🟢 Local provider"]
+    Registry --> Browser["🌐 Browser provider"]
+    Registry -.-> Remote["☁️ Remote provider"]
+```
+
+Models never select providers, create sessions, or synchronize files. The host
+binds those lifecycle decisions before a run.
+
+## 🎛️ Tool Profiles
+
+| Profile | Model-facing tools |
+|---|---|
+| `execution` | `sandbox_inspect`, `sandbox_run`, `sandbox_process`, `sandbox_packages` |
+| `web_app` | execution tools plus `sandbox_preview`, `sandbox_network` |
+| `stateful` | web app tools plus `sandbox_snapshot` |
+
+Capability gating removes tools that the selected provider cannot implement.
+Unsupported operations are absent, not documented optimistically and rejected
+only after the model calls them.
+
+## 🚀 Bind A Provider
+
+```ts
+import { createNodePlatform } from "@memorall/agent-harness-node";
+import { NodeLocalSandboxProvider } from "@memorall/agent-harness-node";
+import {
+  SANDBOX_SERVICE,
+  SandboxManager,
+  SandboxProviderRegistry,
+  sandboxPlugin,
+} from "@memorall/agent-harness-sandbox";
+
+const platform = createNodePlatform();
+const providers = new SandboxProviderRegistry()
+  .register(new NodeLocalSandboxProvider());
+
+const sandbox = new SandboxManager(
+  providers,
+  { providerId: "node-local", sessionPolicy: "reuse-conversation" },
+  platform,
+);
+
+const plugins = [sandboxPlugin({ profile: "web_app" })];
+const services = { [SANDBOX_SERVICE.id]: sandbox };
+```
+
+A remote provider implements `SandboxProvider`; tools, graphs, events, and
+result parsing stay unchanged.
+
+## 🔒 Stable Cross-Provider Contracts
+
+- IDs and process cursors are opaque strings.
+- calls carry operation IDs, cancellation signals, and deadlines;
+- outputs are bounded and report truncation/continuation metadata;
+- failures use stable `SandboxError` codes and retryability metadata;
+- workspace conflicts are reported instead of overwriting newer host files;
+- session lifecycle and workspace flush remain harness-owned.
+
+## 🧪 Provider Conformance
+
+The `@memorall/agent-harness-sandbox/testing` subpath exports a fake remote
+provider and reusable conformance helpers. Every provider should pass the same
+suite before it is advertised to agents.

--- a/packages/agent-harness/standard/README.md
+++ b/packages/agent-harness/standard/README.md
@@ -1,5 +1,70 @@
-# Agent Harness Standard Capabilities
+# 🧰 Agent Harness Standard Capabilities
 
-Opt-in filesystem, web, planning, skills, compaction, chat, and delegation
-plugins. Every environment-dependent operation is supplied through a service
-port.
+> Useful agent abilities with portable contracts and replaceable host services.
+
+[← Workspace guide](../README.md) · **Package:** `@memorall/agent-harness-standard`
+
+Standard capabilities are opt-in building blocks, not a product preset. Tools
+contain model-facing validation and result shaping; filesystem, browser, skill,
+compaction, and child-agent behavior enters through service tokens.
+
+## ✨ Capability Catalog
+
+| Capability | Tools or steps | Required service |
+|---|---|---|
+| 💬 Chat | `add-system`, `current-time` | none |
+| 📁 Filesystem | `fs_read`, `fs_write`, `fs_edit`, `fs_ls`, `fs_glob`, `fs_grep`, `fs_mkdir`, `fs_remove` | `FILESYSTEM_SERVICE` |
+| 🌐 Web | `web_open`, `web_read`, `web_search`, `web_dom`, `web_wait` | `WEB_BROWSER_SERVICE`, optional HTML processor |
+| 📋 Planner | create/get/add/check/remove plan tools | run-local state |
+| 🧠 Skills | `load_skill` | `SKILL_SERVICE` |
+| 🗜️ Compaction | `auto-compact` step | `COMPACTION_SERVICE` |
+| 🤝 Delegation | `send_message_to_agent` | `CHILD_AGENT_SERVICE` |
+
+## 🎛️ Select Only What You Need
+
+```ts
+import { standardToolsPlugin } from "@memorall/agent-harness-standard";
+
+const standard = standardToolsPlugin({
+  chat: { content: "Be concise and verify tool results." },
+  filesystem: true,
+  planner: true,
+  web: false,
+  skills: false,
+  compaction: false,
+  multiAgent: false,
+});
+```
+
+The aggregate plugin enables capabilities by default, so explicitly set
+unneeded features to `false` for the clearest model surface and smallest bundle.
+You can also import focused subpaths such as
+`@memorall/agent-harness-standard/filesystem`.
+
+## 🔌 Bind A Portable Service
+
+```ts
+import { FILESYSTEM_SERVICE } from "@memorall/agent-harness-standard/filesystem";
+import { NodeFileSystem } from "@memorall/agent-harness-node";
+
+const services = {
+  [FILESYSTEM_SERVICE.id]: new NodeFileSystem(),
+};
+```
+
+Use `OpfsFileSystem` from the
+[`browser` package](../browser/README.md) to keep the same tools in a browser.
+The graph and model-facing schema do not change when the host implementation
+changes.
+
+## 📦 Focused Exports
+
+`./chat`, `./filesystem`, `./web`, `./planner`, `./skills`, `./compaction`, and
+`./multi-agent` are public subpaths. Importing one does not register it; call its
+plugin factory and pass the result to `createHarness()`.
+
+## 🛡️ Design Boundary
+
+This package owns domain-neutral agent abilities only. Concrete browser tabs,
+Chrome extension APIs, document databases, prompts, credentials, and UI policy
+remain outside the workspace.


### PR DESCRIPTION
## Summary

- add an umbrella guide for the standalone Agent Harness workspace
- explain how to choose between the full facade and focused packages
- document architecture, lifecycle, runtime guarantees, and verification commands
- expand all nine child-package READMEs with icons, capability tables, examples, boundaries, and related-package links

## Validation

- all 10 Agent Harness READMEs are present
- all local Markdown links resolve
- all fenced code blocks are balanced
- staged patch contains documentation files only
- `git diff --check` passes
- all nine harness workspace boundary checks pass

No runtime code or package API changed.
